### PR TITLE
Fix bug on `coredb` creation

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -138,10 +138,6 @@ impl CoreDB {
         let sts_api: Api<StatefulSet> = Api::namespaced(client, &ns);
         labels.insert("app".to_owned(), "coredb".to_string());
 
-        // if sts_api.get(&name) {
-        //     return
-        // }
-
         let sts: StatefulSet = StatefulSet {
             metadata: ObjectMeta {
                 name: Some(name.to_owned()),
@@ -184,7 +180,7 @@ impl CoreDB {
         };
 
         let mut exists = false;
-        // Create the statefulset defined above
+        // Create the statefulset if it does not exist
         let lp = ListParams::default().labels("app=coredb");
         for _ in sts_api.list(&lp).await.map_err(Error::KubeError)? {
             exists = true
@@ -201,7 +197,7 @@ impl CoreDB {
     async fn delete_sts(&self, client: Client, name: &str, namespace: &str) -> Result<(), Error> {
         let sts: Api<StatefulSet> = Api::namespaced(client, namespace);
         let mut exists = false;
-        // Create the statefulset defined above
+        // Delete the statefulset if it exists
         let lp = ListParams::default().labels("app=coredb");
         for _ in sts.list(&lp).await.map_err(Error::KubeError)? {
             exists = true

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -186,7 +186,7 @@ impl CoreDB {
         let mut exists = false;
         // Create the statefulset defined above
         let lp = ListParams::default().labels("app=coredb");
-        for s in sts_api.list(&lp).await.map_err(Error::KubeError)? {
+        for _ in sts_api.list(&lp).await.map_err(Error::KubeError)? {
             exists = true
         }
         if !exists {
@@ -203,7 +203,7 @@ impl CoreDB {
         let mut exists = false;
         // Create the statefulset defined above
         let lp = ListParams::default().labels("app=coredb");
-        for s in sts.list(&lp).await.map_err(Error::KubeError)? {
+        for _ in sts.list(&lp).await.map_err(Error::KubeError)? {
             exists = true
         }
         if exists {


### PR DESCRIPTION
We observed a bug when creating a `coredb` resource in which the controller will attempt to create the resource even when it exists. This fixes the issue and checks for an existing resource before creation. We're also adding the same check logic for resource deletion.