### PR TITLE
Use owner reference for resource deletion

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -191,7 +191,6 @@ impl CoreDB {
 
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)
     async fn cleanup(&self, ctx: Arc<Context>) -> Result<Action> {
-        let client = ctx.client.clone();
         let recorder = ctx.diagnostics.read().await.recorder(ctx.client.clone(), self);
         // CoreDB doesn't have dependencies in this example case, so we just publish an event
         recorder

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -3,7 +3,7 @@ use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec};
 use k8s_openapi::api::core::v1::{Container, ContainerPort, EnvVar, PodSpec, PodTemplateSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use std::collections::BTreeMap;
-use kube::api::{DeleteParams, ObjectMeta};
+use kube::api::{ObjectMeta};
 use chrono::{DateTime, Utc};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use kube::{

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -189,23 +189,6 @@ impl CoreDB {
         Ok(())
     }
 
-    // async fn delete_sts(&self, client: Client, name: &str, namespace: &str) -> Result<(), Error> {
-    //     let sts: Api<StatefulSet> = Api::namespaced(client, namespace);
-    //     let mut exists = false;
-    //     // Delete the statefulset if it exists
-    //     let lp = ListParams::default().labels("app=coredb");
-    //     for _ in sts.list(&lp).await.map_err(Error::KubeError)? {
-    //         exists = true
-    //     }
-    //     if exists {
-    //         sts
-    //             .delete(name, &DeleteParams::default())
-    //             .await
-    //             .map_err(Error::KubeError)?;
-    //     }
-    //     Ok(())
-    // }
-
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)
     async fn cleanup(&self, ctx: Arc<Context>) -> Result<Action> {
         let client = ctx.client.clone();
@@ -221,9 +204,6 @@ impl CoreDB {
             })
             .await
             .map_err(Error::KubeError)?;
-        // self.delete_sts(client, &self.name_any(), &self.namespace().unwrap())
-        //     .await
-        //     .expect("error deleting statefulset");
         Ok(Action::await_change())
     }
 }


### PR DESCRIPTION
We can use owner references to handle resource deletion instead of our delete function currently implemented. With these changes, we create our stateful set with the parent `CoreDB`resource as its owner. This allows for automatic child resource cleanup upon `CoreDB` deletion. 

Relevant links:
- https://kube.rs/controllers/relations/#owned-relation