### PR TITLE
Remove `hide` spec value from CoreDB resource

### DIFF
--- a/coredb-operator/README.md
+++ b/coredb-operator/README.md
@@ -63,7 +63,7 @@ Try some of:
 ```sh
 kubectl apply -f yaml/sample-coredb.yaml
 kubectl delete coredb sample-coredb
-kubectl edit coredb sample-coredb # change hidden
+kubectl edit coredb sample-coredb # change replicas
 ```
 
 The reconciler will run and write the status object on every change. You should see results in the logs of the pod, or on the .status object outputs of `kubectl get coredb -o yaml`.
@@ -98,8 +98,3 @@ $ curl 0.0.0.0:8080/
 ```
 
 The metrics will be auto-scraped if you have a standard [`PodMonitor` for `prometheus.io/scrape`](https://github.com/prometheus-community/helm-charts/blob/b69e89e73326e8b504102a75d668dc4351fcdb78/charts/prometheus/values.yaml#L1608-L1650).
-
-### Events
-The example `reconciler` only checks the `.spec.hidden` bool. If it does, it updates the `.status` object to reflect whether or not the instance `is_hidden`. It also sends a kubernetes event associated with the controller. It is visible at the bottom of `kubectl describe coredb sample-coredb`.
-
-While this controller has no child objects configured, there is a [`configmapgen_controller`](https://github.com/kube-rs/kube-rs/blob/master/examples/configmapgen_controller.rs) example in [kube-rs](https://github.com/kube-rs/kube-rs/).

--- a/coredb-operator/justfile
+++ b/coredb-operator/justfile
@@ -6,6 +6,11 @@ SEMVER_VERSION := `grep version Cargo.toml | awk -F"\"" '{print $2}' | head -n 1
 default:
   @just --list --unsorted --color=always | rg -v "    default"
 
+# generate crd
+generate-crd:
+  cargo run --bin crdgen > yaml/crd.yaml
+
+
 # generate and install crd into the cluster
 install-crd:
   cargo run --bin crdgen > yaml/crd.yaml

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -1,52 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
   name: coredbs.kube.rs
 spec:
-  conversion:
-    strategy: None
   group: kube.rs
   names:
+    categories: []
     kind: CoreDB
-    listKind: CoreDBList
     plural: coredbs
     shortNames:
-      - cdb
+    - cdb
     singular: coredb
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: Auto-generated derived type for CoreDBSpec via `CustomResource`
-          properties:
-            spec:
-              description: |-
-                Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
+  - additionalPrinterColumns: []
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for CoreDBSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
 
-                This provides a hook for generating the CRD yaml (in crdgen.rs)
-              properties:
-                hide:
-                  type: boolean
-                replicas:
-                  format: int32
-                  type: integer
-              required:
-                - hide
-                - replicas
-              type: object
-            status:
-              description: The status object of `CoreDB`
-              nullable: true
-              properties:
-                hidden:
-                  type: boolean
-              required:
-                - hidden
-              type: object
-          required:
-            - spec
-          title: CoreDB
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+              This provides a hook for generating the CRD yaml (in crdgen.rs)
+            properties:
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - replicas
+            type: object
+          status:
+            description: The status object of `CoreDB`
+            nullable: true
+            properties:
+              running:
+                type: boolean
+            required:
+            - running
+            type: object
+        required:
+        - spec
+        title: CoreDB
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/coredb-operator/yaml/sample-coredb.yaml
+++ b/coredb-operator/yaml/sample-coredb.yaml
@@ -4,4 +4,3 @@ metadata:
   name: sample-coredb
 spec:
   replicas: 1
-  hide: false


### PR DESCRIPTION
The `hide` spec value was leftover from example code. Removing this spec value and any related code as we won't need it. Also adding a `generate-crd` command to our justfile and updating the `crd.yaml` file with our new spec.