### PR TITLE
Pg metrics

### DIFF
--- a/extensions/prometheus_exporter/Cargo.toml
+++ b/extensions/prometheus_exporter/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.2.1"
+futures = "0.3.25"
 pgx = "0.6.1"
 prometheus-client = "0.19.0-alpha.2"
+tokio = {version = "1.23.0", features = ["macros", "rt-multi-thread"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/extensions/prometheus_exporter/README.md
+++ b/extensions/prometheus_exporter/README.md
@@ -3,3 +3,6 @@
 Proof-of-concept
 
 
+```bash
+echo "shared_preload_libraries = 'prometheus_exporter.so'" >> ~/.pgx/data-14/postgresql.conf
+```

--- a/extensions/prometheus_exporter/src/lib.rs
+++ b/extensions/prometheus_exporter/src/lib.rs
@@ -2,9 +2,9 @@ use pgx::bgworkers::*;
 use pgx::log;
 use pgx::prelude::*;
 
-pgx::pg_module_magic!();
-
 mod webserver;
+
+pgx::pg_module_magic!();
 
 #[allow(non_snake_case)]
 #[pg_guard]
@@ -31,4 +31,9 @@ pub extern "C" fn serve_metrics(_arg: pg_sys::Datum) {
         "Closing BGWorker: {}",
         BackgroundWorker::get_name()
     );
+}
+
+#[pg_extern]
+pub fn yolo() -> String{
+    "yolo".to_string()
 }

--- a/extensions/prometheus_exporter/src/lib.rs
+++ b/extensions/prometheus_exporter/src/lib.rs
@@ -32,8 +32,3 @@ pub extern "C" fn serve_metrics(_arg: pg_sys::Datum) {
         BackgroundWorker::get_name()
     );
 }
-
-#[pg_extern]
-pub fn yolo() -> String{
-    "yolo".to_string()
-}

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -1,12 +1,23 @@
 // https://github.com/prometheus/client_rust/blob/master/examples/actix-web.rs
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use std::{thread, time};
 
 use actix_web::{web, App, HttpResponse, HttpServer, Responder, Result};
+
+use tokio::{task}; // 1.3.0
+
+use pgx::bgworkers::*;
+use pgx::prelude::*;
+
 use prometheus_client::encoding::text::encode;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
+
+const UPTIME_QUERY: &str = "SELECT FLOOR(EXTRACT(EPOCH FROM now() - pg_postmaster_start_time))
+FROM pg_postmaster_start_time();";
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 pub enum Method {
@@ -18,13 +29,29 @@ pub struct MethodLabels {
     pub method: Method,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct UptimeLabels {
+    pub label: String,
+}
+
+
 pub struct Metrics {
     requests: Family<MethodLabels, Counter>,
+    uptime: Family<(), Gauge>,
 }
 
 impl Metrics {
     pub fn inc_requests(&self, method: Method) {
         self.requests.get_or_create(&MethodLabels { method }).inc();
+    }
+
+    pub fn pg_uptime(&self) {
+        let res = query();
+        println!("res: {:?}", res);
+        match res {
+            Some(t) => self.uptime.get_or_create(&()).set(t),
+            None => panic!("Could not get uptime from Postgres"),
+        };
     }
 }
 
@@ -33,6 +60,7 @@ pub struct AppState {
 }
 
 pub async fn metrics_handler(state: web::Data<Mutex<AppState>>) -> Result<HttpResponse> {
+    println!("metrics_handler called");
     let state = state.lock().unwrap();
     let mut body = String::new();
     encode(&mut body, &state.registry).unwrap();
@@ -41,31 +69,85 @@ pub async fn metrics_handler(state: web::Data<Mutex<AppState>>) -> Result<HttpRe
         .body(body))
 }
 
-pub async fn some_handler(metrics: web::Data<Metrics>) -> impl Responder {
-    metrics.inc_requests(Method::Get);
-    "okay".to_string()
+
+pub async fn test() -> impl Responder {
+    "test".to_string()
+}
+
+pub async fn update_metrics(metrics_clone: Arc<Mutex<Metrics>>) -> impl Responder {
+    println!("updating metrics");
+    
+    let metrics = metrics_clone.lock().unwrap();
+    loop {
+        // TODO: this needs to be interruptable
+        metrics.pg_uptime();
+        metrics.inc_requests(Method::Get);
+        thread::sleep(time::Duration::from_millis(2500));
+    }
+    "done".to_string()
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn query() -> Option<i64> {
+    let uptime = Arc::new(Mutex::new(i64::default()));
+    let clone = Arc::clone(&uptime);
+    println!("query called");
+    // BackgroundWorker::transaction(move || {
+    //     let ut: Option<i64> = Spi::get_one(UPTIME_QUERY);
+    //     match ut {
+    //         Some(t) => println!("t: {:?}", t),
+    //         None => println!("no value"),
+    //     }
+    // });
+    BackgroundWorker::transaction(move || {
+        Spi::execute(|client| {
+            println!("query called (inside spi");
+            let tuple_table = client.select(UPTIME_QUERY, None, None);
+            println!("tuple_table: {:?}", tuple_table);
+            for tup in tuple_table {
+                let uptime = tup.by_name("floor").unwrap().value::<i64>().unwrap();
+                let mut obj_clone = clone.lock().unwrap();
+                *obj_clone = uptime;
+                break
+            }
+        });
+    });
+    let x = Some(*uptime.lock().unwrap());
+    println!("uptime: {:?}", x);
+    x
 }
 
 #[actix_web::main]
 pub async fn serve() -> std::io::Result<()> {
-    let metrics = web::Data::new(Metrics {
+    let metrics = Metrics {
         requests: Family::default(),
-    });
+        uptime: Family::default(),
+    };
+    
     let mut state = AppState {
         registry: Registry::default(),
     };
+    
     state
-        .registry
-        .register("requests", "Count of requests", metrics.requests.clone());
+    .registry
+    .register("requests", "Count of requests", metrics.requests.clone());
+    state.registry
+    .register("pg_uptime", "Postgres server uptime", metrics.uptime.clone());
     let state = web::Data::new(Mutex::new(state));
+
+    let mutex_metrics = Arc::new(Mutex::new(metrics));
+    let metrics_clone = Arc::clone(&mutex_metrics);
+
+    task::spawn(async { update_metrics(metrics_clone).await; });
+
     HttpServer::new(move || {
         App::new()
-            .app_data(metrics.clone())
-            .app_data(state.clone())
-            .service(web::resource("/metrics").route(web::get().to(metrics_handler)))
-            .service(web::resource("/alive").route(web::get().to(some_handler)))
+        .app_data(state.clone())
+        .service(web::resource("/metrics").route(web::get().to(metrics_handler)))
+        .service(web::resource("/").route(web::get().to(test)))
     })
     .bind(("127.0.0.1", 8080))?
     .run()
     .await
+
 }

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -92,13 +92,6 @@ fn query() -> Option<i64> {
     let uptime = Arc::new(Mutex::new(i64::default()));
     let clone = Arc::clone(&uptime);
     println!("query called");
-    // BackgroundWorker::transaction(move || {
-    //     let ut: Option<i64> = Spi::get_one(UPTIME_QUERY);
-    //     match ut {
-    //         Some(t) => println!("t: {:?}", t),
-    //         None => println!("no value"),
-    //     }
-    // });
     BackgroundWorker::transaction(move || {
         Spi::execute(|client| {
             println!("query called (inside spi");


### PR DESCRIPTION
Sets pattern for exporting pg server metrics. two bugs currently exist:
1. background thread doesn't get killed when pgx stops
2. the query result seems to have some strange type casting. e.g. expecting a value ~100 and getting some very large int like 4974814424