### PR TITLE
cast types properly

### DIFF
--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -16,7 +16,7 @@ use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
 
-const UPTIME_QUERY: &str = "SELECT FLOOR(EXTRACT(EPOCH FROM now() - pg_postmaster_start_time))
+const UPTIME_QUERY: &str = "SELECT FLOOR(EXTRACT(EPOCH FROM now() - pg_postmaster_start_time))::bigint
 FROM pg_postmaster_start_time();";
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]


### PR DESCRIPTION
the uptime metric is now set properly. I was previously trying to cast a the `numeric` to `i64`. Instead, cast the resultset to `bigint` in the query, which `pgx` can then map to `i64`.