### PR TITLE
fix exporter kill bug

### DIFF
--- a/extensions/prometheus_exporter/Cargo.toml
+++ b/extensions/prometheus_exporter/Cargo.toml
@@ -7,14 +7,13 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.2.1"
-futures = "0.3.25"
 pgx = "0.6.1"
 prometheus-client = "0.19.0-alpha.2"
+signal-hook = "0.3.14"
 tokio = {version = "1.23.0", features = ["macros", "rt-multi-thread"] }
 
 [lib]
 crate-type = ["cdylib"]
-
 
 [features]
 default = ["pg13"]

--- a/extensions/prometheus_exporter/src/lib.rs
+++ b/extensions/prometheus_exporter/src/lib.rs
@@ -17,7 +17,6 @@ pub extern "C" fn _PG_init() {
         .load();
 }
 
-
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn serve_metrics(_arg: pg_sys::Datum) {
@@ -27,8 +26,5 @@ pub extern "C" fn serve_metrics(_arg: pg_sys::Datum) {
 
     webserver::serve().unwrap();
 
-    log!(
-        "Closing BGWorker: {}",
-        BackgroundWorker::get_name()
-    );
+    log!("Closing BGWorker: {}", BackgroundWorker::get_name());
 }

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -12,7 +12,7 @@ use pgx::bgworkers::*;
 use pgx::prelude::*;
 
 use prometheus_client::encoding::text::encode;
-use prometheus_client::encoding::{EncodeLabelSet};
+use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
@@ -81,7 +81,7 @@ fn handle_pg_uptime() -> Option<i64> {
         log!("pg_uptime: {:?}", obj_clone);
     });
     let x = Some(*uptime.lock().unwrap());
-    
+
     x
 }
 

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -9,6 +9,7 @@ use actix_web::{web, App, HttpResponse, HttpServer, Result};
 use tokio::task;
 
 use pgx::bgworkers::*;
+use pgx::log;
 use pgx::prelude::*;
 
 use prometheus_client::encoding::text::encode;
@@ -67,8 +68,6 @@ pub async fn update_metrics(metrics_clone: Arc<Mutex<Metrics>>) {
 fn pg_uptime() -> Option<i64> {
     Spi::get_one(UPTIME_QUERY)
 }
-
-use pgx::log;
 
 fn handle_pg_uptime() -> Option<i64> {
     let uptime = Arc::new(Mutex::new(i64::default()));

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -1,57 +1,38 @@
 // https://github.com/prometheus/client_rust/blob/master/examples/actix-web.rs
+use signal_hook::flag;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
 
-use actix_web::{web, App, HttpResponse, HttpServer, Responder, Result};
+use actix_web::{web, App, HttpResponse, HttpServer, Result};
 
-use tokio::{task}; // 1.3.0
+use tokio::task;
 
 use pgx::bgworkers::*;
 use pgx::prelude::*;
 
 use prometheus_client::encoding::text::encode;
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
+use prometheus_client::encoding::{EncodeLabelSet};
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
 
-const UPTIME_QUERY: &str = "SELECT FLOOR(EXTRACT(EPOCH FROM now() - pg_postmaster_start_time))::bigint
+const UPTIME_QUERY: &str =
+    "SELECT FLOOR(EXTRACT(EPOCH FROM now() - pg_postmaster_start_time))::bigint
 FROM pg_postmaster_start_time();";
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
-pub enum Method {
-    Get,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct MethodLabels {
-    pub method: Method,
-}
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct UptimeLabels {
     pub label: String,
 }
 
-
 pub struct Metrics {
-    requests: Family<MethodLabels, Counter>,
     uptime: Family<(), Gauge>,
 }
 
 impl Metrics {
-    pub fn inc_requests(&self, method: Method) {
-        self.requests.get_or_create(&MethodLabels { method }).inc();
-    }
-
-    pub fn pg_uptime(&self) {
-        let res = query();
-        println!("res: {:?}", res);
-        match res {
-            Some(t) => self.uptime.get_or_create(&()).set(t),
-            None => panic!("Could not get uptime from Postgres"),
-        };
+    pub fn pg_uptime(&self, uptime: i64) {
+        self.uptime.get_or_create(&()).set(uptime);
     }
 }
 
@@ -60,7 +41,6 @@ pub struct AppState {
 }
 
 pub async fn metrics_handler(state: web::Data<Mutex<AppState>>) -> Result<HttpResponse> {
-    println!("metrics_handler called");
     let state = state.lock().unwrap();
     let mut body = String::new();
     encode(&mut body, &state.registry).unwrap();
@@ -69,78 +49,69 @@ pub async fn metrics_handler(state: web::Data<Mutex<AppState>>) -> Result<HttpRe
         .body(body))
 }
 
+pub async fn update_metrics(metrics_clone: Arc<Mutex<Metrics>>) {
+    let term = Arc::new(AtomicBool::new(false));
+    flag::register(signal_hook::consts::SIGTERM, Arc::clone(&term)).unwrap();
 
-pub async fn test() -> impl Responder {
-    "test".to_string()
-}
-
-pub async fn update_metrics(metrics_clone: Arc<Mutex<Metrics>>) -> impl Responder {
-    println!("updating metrics");
-    
     let metrics = metrics_clone.lock().unwrap();
-    loop {
-        // TODO: this needs to be interruptable
-        metrics.pg_uptime();
-        metrics.inc_requests(Method::Get);
-        thread::sleep(time::Duration::from_millis(2500));
+    while !term.load(Ordering::Relaxed) {
+        let uptime: i64 = handle_pg_uptime().unwrap();
+        {
+            metrics.pg_uptime(uptime);
+            thread::sleep(time::Duration::from_millis(2500));
+        }
     }
-    "done".to_string()
 }
 
-#[pg_extern(immutable, parallel_safe)]
-fn query() -> Option<i64> {
+#[pg_extern]
+fn pg_uptime() -> Option<i64> {
+    Spi::get_one(UPTIME_QUERY)
+}
+
+fn handle_pg_uptime() -> Option<i64> {
     let uptime = Arc::new(Mutex::new(i64::default()));
     let clone = Arc::clone(&uptime);
-    println!("query called");
+
+    // interacting with the SPI bust be done in a background worker
     BackgroundWorker::transaction(move || {
-        Spi::execute(|client| {
-            println!("query called (inside spi");
-            let tuple_table = client.select(UPTIME_QUERY, None, None);
-            println!("tuple_table: {:?}", tuple_table);
-            for tup in tuple_table {
-                let uptime = tup.by_name("floor").unwrap().value::<i64>().unwrap();
-                let mut obj_clone = clone.lock().unwrap();
-                *obj_clone = uptime;
-                break
-            }
-        });
+        let mut obj_clone = clone.lock().unwrap();
+        *obj_clone = pg_uptime().unwrap();
     });
     let x = Some(*uptime.lock().unwrap());
-    println!("uptime: {:?}", x);
+    println!("uptime: {:?}", x.unwrap());
     x
 }
 
 #[actix_web::main]
 pub async fn serve() -> std::io::Result<()> {
     let metrics = Metrics {
-        requests: Family::default(),
         uptime: Family::default(),
     };
-    
+
     let mut state = AppState {
         registry: Registry::default(),
     };
-    
-    state
-    .registry
-    .register("requests", "Count of requests", metrics.requests.clone());
-    state.registry
-    .register("pg_uptime", "Postgres server uptime", metrics.uptime.clone());
+
+    state.registry.register(
+        "pg_uptime",
+        "Postgres server uptime",
+        metrics.uptime.clone(),
+    );
     let state = web::Data::new(Mutex::new(state));
 
     let mutex_metrics = Arc::new(Mutex::new(metrics));
     let metrics_clone = Arc::clone(&mutex_metrics);
 
-    task::spawn(async { update_metrics(metrics_clone).await; });
+    task::spawn(async {
+        update_metrics(metrics_clone).await;
+    });
 
     HttpServer::new(move || {
         App::new()
-        .app_data(state.clone())
-        .service(web::resource("/metrics").route(web::get().to(metrics_handler)))
-        .service(web::resource("/").route(web::get().to(test)))
+            .app_data(state.clone())
+            .service(web::resource("/metrics").route(web::get().to(metrics_handler)))
     })
     .bind(("127.0.0.1", 8080))?
     .run()
     .await
-
 }

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -68,6 +68,8 @@ fn pg_uptime() -> Option<i64> {
     Spi::get_one(UPTIME_QUERY)
 }
 
+use pgx::log;
+
 fn handle_pg_uptime() -> Option<i64> {
     let uptime = Arc::new(Mutex::new(i64::default()));
     let clone = Arc::clone(&uptime);
@@ -76,9 +78,10 @@ fn handle_pg_uptime() -> Option<i64> {
     BackgroundWorker::transaction(move || {
         let mut obj_clone = clone.lock().unwrap();
         *obj_clone = pg_uptime().unwrap();
+        log!("pg_uptime: {:?}", obj_clone);
     });
     let x = Some(*uptime.lock().unwrap());
-    println!("uptime: {:?}", x.unwrap());
+    
     x
 }
 


### PR DESCRIPTION
Implemented a signal handler around the metrics update task. This allows `cargo pgx stop` to interrupt and stop the process.

Also cleaned up a bunch of debug code.