### PR TITLE
Add pgexporter tests

### DIFF
--- a/.github/workflows/postgres_extension.yml
+++ b/.github/workflows/postgres_extension.yml
@@ -3,6 +3,9 @@ name: Prometheus Exporter for Postgres
 on:
   pull_request:
     branches: [ main ]
+    paths: 
+    - '.github/workflows/postgres_extension.yml'
+    - 'extensions/**'
 
 jobs:
   build_and_test:

--- a/.github/workflows/postgres_extension.yml
+++ b/.github/workflows/postgres_extension.yml
@@ -1,0 +1,25 @@
+name: Prometheus Exporter for Postgres
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    name: Rust project
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: setup pgx
+        run: cargo install --locked cargo-pgx
+
+      - name: init
+        run: cargo pgx init
+
+      - name: test
+        run: cargo pgx test

--- a/.github/workflows/prom_exporter_ext.yml
+++ b/.github/workflows/prom_exporter_ext.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo install --locked cargo-pgx
 
       - name: init
-        run: cargo pgx init --pg14 download
+        run: run: cargo pgx init --pg14 download
 
       - name: test
         run: cargo test --no-default-features --features pg14

--- a/.github/workflows/prom_exporter_ext.yml
+++ b/.github/workflows/prom_exporter_ext.yml
@@ -1,4 +1,4 @@
-name: Prometheus Exporter for Postgres
+name: Prometheus Exporter for Postgres (pg14)
 
 defaults:
   run:
@@ -27,7 +27,7 @@ jobs:
         run: cargo install --locked cargo-pgx
 
       - name: init
-        run: cargo pgx init
+        run: cargo pgx init --pg14 download
 
       - name: test
-        run: cargo pgx test
+        run: cargo test --no-default-features --features pg14

--- a/.github/workflows/prom_exporter_ext.yml
+++ b/.github/workflows/prom_exporter_ext.yml
@@ -1,5 +1,10 @@
 name: Prometheus Exporter for Postgres
 
+defaults:
+  run:
+    shell: bash
+    working-directory: ./extensions/prometheus_exporter/
+
 on:
   pull_request:
     branches: [ main ]

--- a/extensions/prometheus_exporter/.cargo/config.toml
+++ b/extensions/prometheus_exporter/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.'cfg(target_os="macos")']
+# Postgres symbols won't be available until runtime
+rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/extensions/prometheus_exporter/Cargo.toml
+++ b/extensions/prometheus_exporter/Cargo.toml
@@ -13,16 +13,15 @@ pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
-pg_test = ["pgx-tests"]
-
+pg_test = []
 
 [dependencies]
-actix-web = "4.2.1"
 pgx = "0.6.1"
-pgx-tests = { version = "0.6.1", optional = true }
+actix-web = "4.2.1"
 prometheus-client = "0.19.0-alpha.2"
 signal-hook = "0.3.14"
 tokio = {version = "1.23.0", features = ["macros", "rt-multi-thread"] }
+
 
 [dev-dependencies]
 pgx-tests = "0.6.1"

--- a/extensions/prometheus_exporter/Cargo.toml
+++ b/extensions/prometheus_exporter/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "prometheus_exporter"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-actix-web = "4.2.1"
-pgx = "0.6.1"
-prometheus-client = "0.19.0-alpha.2"
-signal-hook = "0.3.14"
-tokio = {version = "1.23.0", features = ["macros", "rt-multi-thread"] }
 
 [lib]
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg13"]
+default = ["pg14"]
 pg11 = ["pgx/pg11", "pgx-tests/pg11" ]
 pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
 pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
-pg_test = []
+pg_test = ["pgx-tests"]
+
+
+[dependencies]
+actix-web = "4.2.1"
+pgx = "0.6.1"
+pgx-tests = { version = "0.6.1", optional = true }
+prometheus-client = "0.19.0-alpha.2"
+signal-hook = "0.3.14"
+tokio = {version = "1.23.0", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
-pgx-tests = "~0.6.1"
+pgx-tests = "0.6.1"
 
 [profile.dev]
 panic = "unwind"

--- a/extensions/prometheus_exporter/README.md
+++ b/extensions/prometheus_exporter/README.md
@@ -3,6 +3,42 @@
 Proof-of-concept
 
 
+### Developer Setup
+
+If you have not already ran this on your machine, run it now:
+```bash
+cargo pgx init
+```
+
+Enable autoloading of the extension. Note, `data-14` refers to the configuration for Postgres version 14. If you are using a different version, replace `data-14` with the appropriate configuration name, e.g. `data-13` for Postgres 13.
+
 ```bash
 echo "shared_preload_libraries = 'prometheus_exporter.so'" >> ~/.pgx/data-14/postgresql.conf
+```
+
+Compile and run the extension on Postgres 14. This will start Postgres on port 28814. A metrics server will be running on `localhost:8080`.
+
+```bash
+cargo pgx run pg14
+```
+
+Scrape Prometheus metrics:
+
+```bash
+curl localhost:8080/metrics
+```
+```
+# HELP pg_uptime Postgres server uptime.
+# TYPE pg_uptime gauge
+pg_uptime{} 57
+# EOF
+```
+
+
+### Testing
+
+Runs tests:
+
+```bash
+cargo pgx test
 ```

--- a/extensions/prometheus_exporter/src/lib.rs
+++ b/extensions/prometheus_exporter/src/lib.rs
@@ -28,3 +28,15 @@ pub extern "C" fn serve_metrics(_arg: pg_sys::Datum) {
 
     log!("Closing BGWorker: {}", BackgroundWorker::get_name());
 }
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -117,3 +117,15 @@ pub async fn serve() -> std::io::Result<()> {
     .run()
     .await
 }
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use crate::webserver;
+    use pgx::prelude::*;
+
+    #[pg_test]
+    fn test_this() {
+        assert!(webserver::pg_uptime().is_some());
+    }
+}

--- a/extensions/prometheus_exporter/src/webserver.rs
+++ b/extensions/prometheus_exporter/src/webserver.rs
@@ -125,7 +125,7 @@ mod tests {
     use pgx::prelude::*;
 
     #[pg_test]
-    fn test_this() {
+    fn test_pg_uptime() {
         assert!(webserver::pg_uptime().is_some());
     }
 }


### PR DESCRIPTION
- Adds a test for the exporter. Very basic for now and only testing on pg14 (until we can figure out a better way to setup the test tooling).

- Adds a github workflow to run the above test