### PR TITLE
Update Controller RBAC and README

### DIFF
--- a/coredb-operator/README.md
+++ b/coredb-operator/README.md
@@ -16,7 +16,7 @@ As an example; install [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#
 Apply the CRD from [cached file](yaml/crd.yaml), or pipe it from `crdgen` (best if changing it):
 
 ```sh
-cargo +nightly run --bin crdgen | kubectl apply -f -
+cargo run --bin crdgen | kubectl apply -f -
 ```
 
 ### Opentelemetry (optional)
@@ -27,13 +27,13 @@ Setup an opentelemetry collector in your cluster. [Tempo](https://github.com/gra
 ### Locally
 
 ```sh
-cargo +nightly run
+cargo run
 ```
 
 or, with optional telemetry (change as per requirements):
 
 ```sh
-OPENTELEMETRY_ENDPOINT_URL=https://0.0.0.0:55680 RUST_LOG=info,kube=trace,controller=debug cargo +nightly run --features=telemetry
+OPENTELEMETRY_ENDPOINT_URL=https://0.0.0.0:55680 RUST_LOG=info,kube=trace,controller=debug cargo run --features=telemetry
 ```
 
 ### In-cluster

--- a/coredb-operator/README.md
+++ b/coredb-operator/README.md
@@ -19,7 +19,7 @@ Apply the CRD from [cached file](yaml/crd.yaml), or pipe it from `crdgen` (best 
 cargo +nightly run --bin crdgen | kubectl apply -f -
 ```
 
-### Opentelemetry
+### Opentelemetry (optional)
 Setup an opentelemetry collector in your cluster. [Tempo](https://github.com/grafana/helm-charts/tree/main/charts/tempo) / [opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator) / [grafana agent](https://github.com/grafana/helm-charts/tree/main/charts/agent-operator) should all work out of the box. If your collector does not support grpc otlp you need to change the exporter in [`main.rs`](./src/main.rs).
 
 ## Running
@@ -52,11 +52,10 @@ Push the image to your local registry with:
 docker push localhost:5001/controller:<tag>
 ```
 
-Edit the [deployment](./yaml/deployment.yaml)'s image tag appropriately, and then:
+Edit the [deployment](./yaml/deployment.yaml)'s image tag appropriately, then run:
 
 ```sh
 kubectl apply -f yaml/deployment.yaml
-kubectl wait --for=condition=available deploy/coredb-controller --timeout=20s
 kubectl port-forward service/coredb-controller 8080:80
 ```
 

--- a/coredb-operator/yaml/deployment.yaml
+++ b/coredb-operator/yaml/deployment.yaml
@@ -24,6 +24,9 @@ rules:
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 # Binding the role to the account in default
@@ -83,7 +86,7 @@ spec:
       serviceAccountName: coredb-controller
       containers:
       - name: coredb-controller
-        image: localhost:5001/controller:bfc8655a54a24317913afa7b1ff567eb20c0445d
+        image: localhost:5001/controller:ac593af6da990c911652c6e35fb777f36498d6dc
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
- Allow for controller deployment to manage statefulsets
- Update README with more accurate local dev instructions. In the future we should add some steps to our `justfile` for creating a kind cluster + local registry. This will simplify local development for us.