### PR TITLE
[COR-47] Refactor controller functions

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -2,7 +2,7 @@ use crate::{telemetry, Error, Metrics, Result};
 use chrono::{DateTime, Utc};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 
-use crate::statefulset::create_sts;
+use crate::statefulset::reconcile_sts;
 use kube::{
     api::{Api, ListParams, Patch, PatchParams, ResourceExt},
     client::Client,
@@ -97,8 +97,8 @@ impl CoreDB {
             .patch_status(&name, &ps, &new_status)
             .await
             .map_err(Error::KubeError)?;
-        // create statefulset
-        create_sts(self, ctx).await.expect("error creating statefulset");
+        // reconcile statefulset
+        reconcile_sts(self, ctx).await.expect("error reconciling statefulset");
         // If no events were received, check back every minute
         Ok(Action::requeue(Duration::from_secs(60)))
     }

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -98,7 +98,9 @@ impl CoreDB {
             .await
             .map_err(Error::KubeError)?;
         // reconcile statefulset
-        reconcile_sts(self, ctx).await.expect("error reconciling statefulset");
+        reconcile_sts(self, ctx)
+            .await
+            .expect("error reconciling statefulset");
         // If no events were received, check back every minute
         Ok(Action::requeue(Duration::from_secs(60)))
     }

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -33,3 +33,4 @@ mod metrics;
 pub use metrics::Metrics;
 
 #[cfg(test)] pub mod fixtures;
+mod statefulset;

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -15,7 +15,7 @@ use kube::{
 };
 use std::{collections::BTreeMap, sync::Arc};
 
-pub async fn create_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
+pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
     let client = ctx.client.clone();
     let ns = cdb.namespace().unwrap();
     let name = cdb.name_any();

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -1,0 +1,92 @@
+use crate::{Context, CoreDB, Error, Result};
+use k8s_openapi::{
+    api::{
+        apps::v1::{StatefulSet, StatefulSetSpec},
+        core::v1::{
+            Container, ContainerPort, EnvVar, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec,
+            PodTemplateSpec, ResourceRequirements,
+        },
+    },
+    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
+};
+use kube::{
+    api::{Api, ObjectMeta, Patch, PatchParams, ResourceExt},
+    Resource,
+};
+use std::{collections::BTreeMap, sync::Arc};
+
+pub async fn create_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
+    let client = ctx.client.clone();
+    let ns = cdb.namespace().unwrap();
+    let name = cdb.name_any();
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    let mut pvc_requests: BTreeMap<String, Quantity> = BTreeMap::new();
+    let sts_api: Api<StatefulSet> = Api::namespaced(client, &ns);
+    let oref = cdb.controller_owner_ref(&()).unwrap();
+    labels.insert("app".to_owned(), "coredb".to_owned());
+    pvc_requests.insert("storage".to_string(), Quantity("8Gi".to_string()));
+
+    let sts: StatefulSet = StatefulSet {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            namespace: Some(ns.to_owned()),
+            labels: Some(labels.clone()),
+            owner_references: Some(vec![oref]),
+            ..ObjectMeta::default()
+        },
+        spec: Some(StatefulSetSpec {
+            replicas: Some(cdb.spec.replicas),
+            selector: LabelSelector {
+                match_expressions: None,
+                match_labels: Some(labels.clone()),
+            },
+            template: PodTemplateSpec {
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        env: Option::from(vec![EnvVar {
+                            name: "POSTGRES_PASSWORD".to_owned(),
+                            value: Some("password".to_owned()),
+                            value_from: None,
+                        }]),
+                        name: name.to_owned(),
+                        image: Some("docker.io/postgres:15".to_owned()),
+                        ports: Some(vec![ContainerPort {
+                            container_port: 5432,
+                            ..ContainerPort::default()
+                        }]),
+                        ..Container::default()
+                    }],
+                    ..PodSpec::default()
+                }),
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..ObjectMeta::default()
+                }),
+            },
+            volume_claim_templates: Option::from(vec![PersistentVolumeClaim {
+                metadata: ObjectMeta {
+                    name: Some("data".to_string()),
+                    ..ObjectMeta::default()
+                },
+                spec: Some(PersistentVolumeClaimSpec {
+                    access_modes: Some(vec!["ReadWriteOnce".to_owned()]),
+                    resources: Some(ResourceRequirements {
+                        limits: None,
+                        requests: Some(pvc_requests),
+                    }),
+                    ..PersistentVolumeClaimSpec::default()
+                }),
+                status: None,
+            }]),
+            ..StatefulSetSpec::default()
+        }),
+        ..StatefulSet::default()
+    };
+
+    let ps = PatchParams::apply("cntrlr").force();
+    let _o = sts_api
+        .patch(&name, &ps, &Patch::Apply(&sts))
+        .await
+        .map_err(Error::KubeError)?;
+    Ok(())
+}


### PR DESCRIPTION
Move statefulset function into its own file. This pattern will help keep our controller code more legible and maintainable.

Related to:
- https://linear.app/coredb/issue/COR-47/refactor-controller-functions