### PR TITLE
Reformat futures import

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -1,6 +1,9 @@
 use crate::{telemetry, Error, Metrics, Result};
 use chrono::{DateTime, Utc};
-use futures::{future::BoxFuture, FutureExt, StreamExt};
+use futures::{
+    future::{BoxFuture, FutureExt},
+    stream::StreamExt,
+};
 
 use crate::{defaults, service::reconcile_svc, statefulset::reconcile_sts};
 use kube::{


### PR DESCRIPTION
Hello, I believe this import involves two sub-modules from the futures crate, i.e., future and stream. Expanded, I understand it would look like:

```
futures::future::BoxFuture
futures::future::FutureExt
futures::stream::StreamExt
```

Very enthusiastic about your work.

-Evan