### PR TITLE
Updated versions of dependencies

### DIFF
--- a/extensions/dev/http_webserver/benchmarking/Cargo.toml
+++ b/extensions/dev/http_webserver/benchmarking/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-actix-web = "3.0"
-actix-rt = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
-dotenv = "0.11"
-diesel = { version = "1.4", features = ["postgres", "r2d2", "uuid", "chrono"] }
-diesel_migrations = "1.4"
-env_logger = "0.6"
+actix-web = "4.2.1"
+actix-rt = "2.7.0"
+chrono = { version = "0.4.23", features = ["serde"] }
+dotenv = "0.15.0"
+diesel = { version = "2.0.2", features = ["postgres", "r2d2", "uuid", "chrono"] }
+diesel_migrations = "2.0.0"
+env_logger = "0.10.0"
 lazy_static = "1.4"
-listenfd = "0.3"
-serde = "1.0"
-serde_json = "1.0"
-r2d2 = "0.8"
-uuid = { version = "0.6", features = ["serde", "v4"] }
+listenfd = "1.0.0"
+serde = "1.0.152"
+serde_json = "1.0.91"
+r2d2 = "0.8.10"
+uuid = { version = "1.2.2", features = ["serde", "v4"] }


### PR DESCRIPTION
- Updated dependencies.

@ChuckHend: I was interested in this particular Cargo.toml file due to its use of the object relational mapper crate, ```diesel```. If you have not already come across the ```sea-orm``` crate, it might be interesting to take a quick peek. It is an alternative that is built from the ground up with async in mind, and built upon ```sqlx```, which the ```sea-orm``` docs notes works well with ```actix```, ```async-std```, and ```tokio```.

https://www.sea-ql.org/SeaORM/

```diesel``` might also check these boxes, and it should be noted that there is an extension called ```diesel-async```, which may address well one of the critiques, i.e., that it wasn't originally built with async in mind.