### PR TITLE
multiple queue on single client connection

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.0.1-alpha"
+version = "0.0.1-alpha.1"
 edition = "2021"
 
 description = "A Rust client for Postgres Message Queues"

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -12,7 +12,8 @@ docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgre
 use pgmq::{Message, PGMQueue};
 
 
-let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned());
+let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await;
+
 ```
 
 ## Create the queue

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -1,33 +1,25 @@
 # Postgres Message Queue
 
 
-
-
-### Start any PG instance
+### Start any Postgres instance
 ```bash
 docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 ```
 
-
 ## Initialize a queue connection
 
 ```rust
-use pgmq::{Message, PGMQueue, PGMQueueConfig};
+use pgmq::{Message, PGMQueue};
 
-let qconfig = PGMQueueConfig {
-    queue_name: "myqueue".to_owned(),
-    url: "postgres://postgres:postgres@0.0.0.0:5432".to_owned(),
-    vt: 30,
-    delay: 0,
-};
 
-let queue: PGMQueue = qconfig.init().await;
+let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned());
 ```
 
 ## Create the queue
 
 ```rust
-queue.create().await?;
+let myqueue = "myqueue".to_owned();
+queue.create(&myqueue).await?;
 ```
 
 ## Pusblish a message
@@ -35,16 +27,16 @@ queue.create().await?;
 let msg = serde_json::json!({
     "foo": "bar"
 });
-let msg_id = queue.enqueue(&msg).await;
+let msg_id = queue.enqueue(&myqueue, &msg).await;
 ```
 
 ## Read a message
-No messages are returned when the queue is empty or all messages are invisible.
-
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
 
+No messages are returned when the queue is empty or all messages are invisible.
 ```rust
-let read_msg: Message = queue.read().await.unwrap();
+let vt: u32 = 30;
+let read_msg: Message = queue.read(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 ```
 
 ## Delete a message

--- a/crates/pgmq/examples/lifecycle.rs
+++ b/crates/pgmq/examples/lifecycle.rs
@@ -2,9 +2,10 @@ use pgmq::{Message, PGMQueue};
 
 #[tokio::main]
 async fn main() -> Result<(), sqlx::Error> {
-    let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned());
+    let queue: PGMQueue =
+        PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await;
 
-    let myqueue = "myqueue".to_owned();
+    let myqueue = "myqueue1".to_owned();
     queue.create(&myqueue).await?;
 
     let msg = serde_json::json!({

--- a/crates/pgmq/examples/lifecycle.rs
+++ b/crates/pgmq/examples/lifecycle.rs
@@ -1,8 +1,7 @@
-use pgmq::{Message, PGMQueue, PGMQueueConfig};
+use pgmq::{Message, PGMQueue};
 
 #[tokio::main]
 async fn main() -> Result<(), sqlx::Error> {
-
     let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned());
 
     let myqueue = "myqueue".to_owned();
@@ -14,9 +13,11 @@ async fn main() -> Result<(), sqlx::Error> {
     let msg_id = queue.enqueue(&myqueue, &msg).await;
     println!("msg_id: {:?}", msg_id);
 
+    // read a message from myqueue. Set it to become visible 30 seconds from now.
     let read_msg: Message = queue.read(&myqueue, Some(&30_u32)).await.unwrap();
     print!("read_msg: {:?}", read_msg);
 
+    // we're done with that message, so let's delete it from myqueue by passing the msg_id
     let deleted = queue.delete(&myqueue, &read_msg.msg_id).await;
     println!("deleted: {:?}", deleted);
 

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -11,9 +11,7 @@ use sqlx::postgres::PgRow;
 
 mod query;
 
-
 const VT_DEFAULT: u32 = 30;
-
 
 #[derive(Debug)]
 pub struct Message {
@@ -29,7 +27,10 @@ pub struct PGMQueue {
 
 impl PGMQueue {
     pub fn new(url: String) -> PGMQueue {
-        PGMQueue { url: url, connection: None }
+        PGMQueue {
+            url: url,
+            connection: None,
+        }
     }
 
     pub async fn connect(&mut self) {
@@ -53,7 +54,11 @@ impl PGMQueue {
         Ok(())
     }
 
-    pub async fn enqueue(&self, queue_name: &str, message: &serde_json::Value) -> Result<i64, Error> {
+    pub async fn enqueue(
+        &self,
+        queue_name: &str,
+        message: &serde_json::Value,
+    ) -> Result<i64, Error> {
         // TODO: sends any struct that can be serialized to json
         // struct will need to derive serialize
         let row: PgRow = sqlx::query(&query::enqueue(&queue_name, &message))
@@ -67,7 +72,7 @@ impl PGMQueue {
         // map vt or default VT
         let vt_ = match vt {
             Some(t) => t,
-            None => &VT_DEFAULT
+            None => &VT_DEFAULT,
         };
         let query = &query::read(&queue_name, &vt_);
         let row = sqlx::query(query)
@@ -105,23 +110,3 @@ pub struct PGMQueueConfig {
     pub vt: u32,
     pub delay: u32,
 }
-
-// impl PGMQueueConfig {
-//     pub fn new() -> PGMQueueConfig {
-//         PGMQueueConfig {
-//             url: "postgres://postgres:postgres@0.0.0.0:5432".to_owned(),
-//             queue_name: "default".to_owned(),
-//             vt: 30,
-//             delay: 0,
-//         }
-//     }
-
-//     pub async fn init(self) -> PGMQueue {
-//         let mut q = PGMQueue {
-//             config: self,
-//             connection: None,
-//         };
-//         q.connect().await;
-//         q
-//     }
-// }

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -1,13 +1,9 @@
 use chrono;
 use sqlx::types::chrono::Utc;
 
-use sqlx::postgres::PgPoolOptions;
-use sqlx::Pool;
-use sqlx::Postgres;
-use sqlx::Row;
-
 use sqlx::error::Error;
-use sqlx::postgres::PgRow;
+use sqlx::postgres::{PgPoolOptions, PgRow};
+use sqlx::{Pool, Postgres, Row};
 
 mod query;
 
@@ -20,37 +16,35 @@ pub struct Message {
     pub message: serde_json::Value,
 }
 
+#[derive(Debug)]
 pub struct PGMQueue {
     pub url: String,
-    pub connection: Option<Pool<Postgres>>,
+    pub connection: Pool<Postgres>,
 }
 
 impl PGMQueue {
-    pub fn new(url: String) -> PGMQueue {
+    pub async fn new(url: String) -> PGMQueue {
+        let con = PGMQueue::connect(&url).await;
         PGMQueue {
             url: url,
-            connection: None,
+            connection: con,
         }
     }
 
-    pub async fn connect(&mut self) {
-        let con = PgPoolOptions::new()
+    async fn connect(url: &str) -> Pool<Postgres> {
+        PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(10))
             .max_connections(5)
-            .connect(&self.url)
+            .connect(&url)
             .await
-            .unwrap();
-        self.connection = Some(con);
+            .expect("connection failed")
     }
 
     pub async fn create(&self, queue_name: &str) -> Result<(), Error> {
         let create = query::create(&queue_name);
         let index: String = query::create_index(&queue_name);
-        sqlx::query(&create)
-            .execute(self.connection.as_ref().unwrap())
-            .await?;
-        sqlx::query(&index)
-            .execute(self.connection.as_ref().unwrap())
-            .await?;
+        sqlx::query(&create).execute(&self.connection).await?;
+        sqlx::query(&index).execute(&self.connection).await?;
         Ok(())
     }
 
@@ -62,7 +56,7 @@ impl PGMQueue {
         // TODO: sends any struct that can be serialized to json
         // struct will need to derive serialize
         let row: PgRow = sqlx::query(&query::enqueue(&queue_name, &message))
-            .fetch_one(self.connection.as_ref().unwrap())
+            .fetch_one(&self.connection)
             .await?;
 
         Ok(row.try_get("msg_id").unwrap())
@@ -75,9 +69,7 @@ impl PGMQueue {
             None => &VT_DEFAULT,
         };
         let query = &query::read(&queue_name, &vt_);
-        let row = sqlx::query(query)
-            .fetch_one(self.connection.as_ref().unwrap())
-            .await;
+        let row = sqlx::query(query).fetch_one(&self.connection).await;
 
         match row {
             Ok(row) => Some(Message {
@@ -91,9 +83,7 @@ impl PGMQueue {
 
     pub async fn delete(&self, queue_name: &str, msg_id: &i64) -> Result<u64, Error> {
         let query = &&query::delete(&queue_name, &msg_id);
-        let row = sqlx::query(query)
-            .execute(self.connection.as_ref().unwrap())
-            .await?;
+        let row = sqlx::query(query).execute(&self.connection).await?;
         let num_deleted = row.rows_affected();
         println!("num_deleted: {}", num_deleted);
         Ok(num_deleted)


### PR DESCRIPTION
Enable one set of database connection (an instance of `PGMQueue`) to send messages to multiple queues.

In the process of implementing that, I realized the `PGMQueueConfig` was unnecessary and clunky, so I removed it.