### PR TITLE
[COR-102] Run postgres pod as 'postgres' user

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -39,6 +39,8 @@ pub struct CoreDBSpec {
     pub image: String,
     #[serde(default = "defaults::default_port")]
     pub port: i32,
+    #[serde(default = "defaults::default_uid")]
+    pub uid: i32,
 }
 
 /// The status object of `CoreDB`

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -2,6 +2,10 @@ pub fn default_replicas() -> i32 {
     1
 }
 
+pub fn default_uid() -> i32 {
+    999
+}
+
 pub fn default_port() -> i32 {
     5432
 }

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -33,7 +33,6 @@ mod metrics;
 pub use metrics::Metrics;
 
 mod defaults;
-#[cfg(test)]
-pub mod fixtures;
+#[cfg(test)] pub mod fixtures;
 mod service;
 mod statefulset;

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -33,6 +33,7 @@ mod metrics;
 pub use metrics::Metrics;
 
 mod defaults;
-#[cfg(test)] pub mod fixtures;
+#[cfg(test)]
+pub mod fixtures;
 mod service;
 mod statefulset;

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -41,8 +41,7 @@ fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
     let postgres_container = Container {
         env: postgres_env.clone(),
         security_context: Some(SecurityContext {
-            //run_as_user: Some(cdb.spec.uid.clone() as i64),
-            run_as_user: Some(999),
+            run_as_user: Some(cdb.spec.uid.clone() as i64),
             allow_privilege_escalation: Some(false),
             ..SecurityContext::default()
         }),
@@ -135,8 +134,11 @@ mod tests {
     use kube::Resource;
 
     #[test]
-    fn test_default_uid() {
-        let mut coredb: CoreDB = CoreDB::new("check-uid-default", CoreDBSpec::default());
+    fn test_user_specified_uid() {
+        let mut cdb_spec: CoreDBSpec = CoreDBSpec::default();
+        cdb_spec.uid = 1000;
+        let mut coredb: CoreDB = CoreDB::new("check-uid", cdb_spec);
+
         coredb.meta_mut().namespace = Some("default".into());
         coredb.meta_mut().uid = Some("752d59ef-2671-4890-9feb-0097459b18c8".into());
         let sts: StatefulSet = stateful_set_from_cdb(&coredb);
@@ -153,7 +155,7 @@ mod tests {
                 .expect("Did not have a security context")
                 .run_as_user
                 .unwrap(),
-            999
+            1000
         );
     }
 }

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -4,7 +4,7 @@ use k8s_openapi::{
         apps::v1::{StatefulSet, StatefulSetSpec},
         core::v1::{
             Container, ContainerPort, EnvVar, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec,
-            PodTemplateSpec, ResourceRequirements, VolumeMount,
+            PodTemplateSpec, ResourceRequirements, SecurityContext, VolumeMount,
         },
     },
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
@@ -13,6 +13,7 @@ use kube::{
     api::{Api, ObjectMeta, Patch, PatchParams, ResourceExt},
     Resource,
 };
+
 use std::{collections::BTreeMap, sync::Arc};
 
 pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
@@ -48,6 +49,11 @@ pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error>
                             value: Some("password".to_owned()),
                             value_from: None,
                         }]),
+                        security_context: Some(SecurityContext {
+                            run_as_user: Some(999),
+                            allow_privilege_escalation: Some(false),
+                            ..SecurityContext::default()
+                        }),
                         name: name.to_owned(),
                         image: Some(cdb.spec.image.clone()),
                         ports: Some(vec![ContainerPort {


### PR DESCRIPTION
Since the container we are using, for now, was intended to run in Docker in a single "run" command, it starts as root, adjusts the permissions on the directory, then switches into postgres user to start postgres.

When working on getting psql commands to run using 'kubectl exec', I noticed an issue where by default it will exec with the root user because of this initialization step. In this PR, I refactored the initialization into an initContainer.

Also, I adjusted the test to assert the container is Ready. I noticed that the test previously only checked the container is running, but test would pass if the Pod then crashed.