### PR TITLE
add fifo test

### DIFF
--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -84,7 +84,6 @@ impl PGMQueue {
         let query = &&query::delete(queue_name, msg_id);
         let row = sqlx::query(query).execute(&self.connection).await?;
         let num_deleted = row.rows_affected();
-        println!("num_deleted: {}", num_deleted);
         Ok(num_deleted)
     }
 

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -39,6 +39,7 @@ pub fn read(name: &str, vt: &u32) -> String {
             SELECT msg_id, vt, message
             FROM {TABLE_PREFIX}_{name}
             WHERE vt <= now() at time zone 'utc'
+            ORDER BY msg_id ASC
             LIMIT 1
             FOR UPDATE SKIP LOCKED
         )


### PR DESCRIPTION
Test to ensure messages are always FIFO, which uncovered bug. PR adds the test and fixes the bug.