### PR TITLE
release pgmq 0.0.1

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.0.1-alpha.1"
+version = "0.0.1"
 edition = "2021"
 
 description = "A Rust client for Postgres Message Queues"


### PR DESCRIPTION
There's no automation set up for publishing yet. It is still manual for now.