### PR TITLE
trim tokio dependencies

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 description = "A Rust client for Postgres Message Queues"

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = "1.0.152"
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros"] }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
`pgmq` only needs the tokio macros feature, not the entire set. This should decrease compile times and size of the binary a little bit.