### PR TITLE
update `pgmq` doc tooling

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = "1.0.152"
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -2,14 +2,14 @@
 name = "pgmq"
 version = "0.0.2"
 edition = "2021"
-
-description = "A Rust client for Postgres Message Queues"
-documentation = "https://github.com/CoreDB-io/coredb/crates/pgmq"
+authors = ["CoreDB.io"]
+description = "A message queue for Rust applications. The only external dependency is a Postgres database."
+documentation = "https://docs.rs/pgmq"
 homepage = "https://www.coredb.io"
 keywords = ["messaging", "queues", "postgres"]
 license = "MIT"
 readme = "README.md"
-repo = "https://github.com/CoreDB-io/coredb/crates/pgmq"
+repo = "https://github.com/CoreDB-io/coredb/tree/main/crates/pgmq"
 
 [dependencies]
 chrono = { version = "0.4.23", features = [ "serde" ] }

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "pgmq"
-title = "Postgres Message Queue"
 version = "0.0.2"
 edition = "2021"
 authors = ["CoreDB.io"]
@@ -14,7 +13,7 @@ repo = "https://github.com/CoreDB-io/coredb/tree/main/crates/pgmq"
 
 [dependencies]
 chrono = { version = "0.4.23", features = [ "serde" ] }
-serde = "1.0.152"
+serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
 tokio = { version = "1", features = ["full"] }
@@ -22,4 +21,3 @@ tokio = { version = "1", features = ["full"] }
 [dev-dependencies]
 cargo-readme = "3.2.0"
 rand = "0.8.5"
-readme-sync = "0.2.1"

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = "1.0.152"
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pgmq"
+title = "Postgres Message Queue"
 version = "0.0.2"
 edition = "2021"
 authors = ["CoreDB.io"]
@@ -19,4 +20,6 @@ sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", 
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
+cargo-readme = "3.2.0"
 rand = "0.8.5"
+readme-sync = "0.2.1"

--- a/crates/pgmq/Makefile
+++ b/crates/pgmq/Makefile
@@ -1,5 +1,8 @@
 POSTGRES_PASSWORD:=postgres
 
+update.readme:
+	cargo readme --no-indent-headings > README.md 
+
 run.docker:
 	docker run --rm -d --name postgres -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 postgres:15.1
 

--- a/crates/pgmq/Makefile
+++ b/crates/pgmq/Makefile
@@ -1,7 +1,10 @@
 POSTGRES_PASSWORD:=postgres
 
 update.readme:
-	cargo readme --no-indent-headings > README.md 
+	cargo readme \
+		--no-title \
+		--no-indent-headings \
+		> README.md
 
 run.docker:
 	docker run --rm -d --name postgres -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 postgres:15.1

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -1,44 +1,39 @@
-# Postgres Message Queue
+# pgmq
 
+## Postgres Message Queue
+A lightweight messaging queue for Rust, using Postgres as the backend.
+Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
+## Examples
 
-### Start any Postgres instance
+First, start any Postgres instance. It is the only external dependency.
+
 ```bash
 docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 ```
-
-## Initialize a queue connection
+## Create a queue
 
 ```rust
 use pgmq::{Message, PGMQueue};
+let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
 
-
-let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await;
-
-```
-
-## Create the queue
-
-```rust
 let myqueue = "myqueue".to_owned();
-queue.create(&myqueue).await?;
+queue.create(&myqueue).await.expect("Failed to create queue");
 ```
 
-## Sending messages to the queue
+## Sending messages
 
 `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
 
-### JSON message
+#### as serde_json::Value
 ```rust
 let msg = serde_json::json!({
     "foo": "bar"
 });
-let msg_id = queue.enqueue(&myqueue, &msg).await;
+let msg_id = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
 ```
-
-### Struct messages
+#### as a struct
 ```rust
 use serde::{Serialize, Deserialize};
-
 #[derive(Serialize, Debug, Deserialize)]
 struct MyMessage {
     foo: String,
@@ -46,40 +41,34 @@ struct MyMessage {
 let msg = MyMessage {
     foo: "bar".to_owned(),
 };
-let msg_id: i64  = queue.enqueue(&myqueue, &msg).await;
+let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
 ```
-
-## Reading messages from the queue
-
+## Reading messages
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
-
 No messages are returned when the queue is empty or all messages are invisible.
-
-Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>` where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct. 
-
-Note that when parsing into a `struct`, the application will panic if the message cannot be parsed as the type specified. For example, if the message expected is `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
-
-### as JSON
+Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>`
+where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct.
+Note that when parsing into a `struct`, the application will panic if the message cannot be
+parsed as the type specified. For example, if the message expected is
+`MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
+#### as serde_json::Value
 ```rust
 use serde_json::Value;
-
 let vt: u32 = 30;
 let read_msg: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 ```
-
-### as a Struct
+#### as a Struct
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
-
 No messages are returned when the queue is empty or all messages are invisible.
 ```rust
 use serde_json::Value;
-
 let vt: u32 = 30;
 let read_msg: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 ```
-
 ## Delete a message
 Remove the message from the queue when you are done with it.
 ```rust
 let deleted = queue.delete(&read_msg.msg_id).await;
 ```
+
+License: MIT

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -1,6 +1,5 @@
-# pgmq
+# Postgres Message Queue
 
-## Postgres Message Queue
 A lightweight messaging queue for Rust, using Postgres as the backend.
 Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
 ## Examples
@@ -43,6 +42,7 @@ let msg = MyMessage {
 };
 let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
 ```
+
 ## Reading messages
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
 No messages are returned when the queue is empty or all messages are invisible.

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -2,7 +2,8 @@
 
 A lightweight messaging queue for Rust, using Postgres as the backend.
 Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
-## Examples
+
+# Examples
 
 First, start any Postgres instance. It is the only external dependency.
 

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -1,3 +1,78 @@
+//! ## Postgres Message Queue
+//! A lightweight messaging queue for Rust, using Postgres as the backend.
+//! Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
+//! ## Examples
+//! 
+//! First, start any Postgres instance. It is the only external dependency.
+//! 
+//! ```bash
+//! docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
+//! ```
+//! ## Create a queue
+//! 
+//! ```rust
+//! use pgmq::{Message, PGMQueue};
+//! let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+//! 
+//! let myqueue = "myqueue".to_owned();
+//! queue.create(&myqueue).await.expect("Failed to create queue");
+//! ```
+//!
+//! ## Sending messages
+//! 
+//! `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
+//! 
+//! #### as serde_json::Value
+//! ```rust
+//! let msg = serde_json::json!({
+//!     "foo": "bar"
+//! });
+//! let msg_id = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
+//! ```
+
+//! #### as a struct
+//! ```rust
+//! use serde::{Serialize, Deserialize};
+//! #[derive(Serialize, Debug, Deserialize)]
+//! struct MyMessage {
+//!     foo: String,
+//! }
+//! let msg = MyMessage {
+//!     foo: "bar".to_owned(),
+//! };
+//! let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
+//! ```
+
+//! ## Reading messages
+//! Reading a message will make it invisible for the duration of the visibility timeout (vt).
+//! No messages are returned when the queue is empty or all messages are invisible.
+//! Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>` 
+//! where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct. 
+//! Note that when parsing into a `struct`, the application will panic if the message cannot be 
+//! parsed as the type specified. For example, if the message expected is 
+//! `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
+
+//! #### as serde_json::Value
+//! ```rust
+//! use serde_json::Value;
+//! let vt: u32 = 30;
+//! let read_msg: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+//! ```
+//! #### as a Struct
+//! Reading a message will make it invisible for the duration of the visibility timeout (vt).
+//! No messages are returned when the queue is empty or all messages are invisible.
+//! ```rust
+//! use serde_json::Value;
+//! let vt: u32 = 30;
+//! let read_msg: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+//! ```
+//! ## Delete a message
+//!Remove the message from the queue when you are done with it.
+//! ```rust
+//! let deleted = queue.delete(&read_msg.msg_id).await;
+//! ```
+
+
 use serde::{Deserialize, Serialize};
 use sqlx::error::Error;
 use sqlx::postgres::{PgPoolOptions, PgRow};

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! A lightweight messaging queue for Rust, using Postgres as the backend.
 //! Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
-//! ## Examples
+//! 
+//! # Examples
 //!
 //! First, start any Postgres instance. It is the only external dependency.
 //!

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -1,27 +1,28 @@
-//! ## Postgres Message Queue
+//! # Postgres Message Queue
+//!
 //! A lightweight messaging queue for Rust, using Postgres as the backend.
 //! Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
 //! ## Examples
-//! 
+//!
 //! First, start any Postgres instance. It is the only external dependency.
-//! 
+//!
 //! ```bash
 //! docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 //! ```
 //! ## Create a queue
-//! 
+//!
 //! ```rust
 //! use pgmq::{Message, PGMQueue};
 //! let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
-//! 
+//!
 //! let myqueue = "myqueue".to_owned();
 //! queue.create(&myqueue).await.expect("Failed to create queue");
 //! ```
 //!
 //! ## Sending messages
-//! 
+//!
 //! `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
-//! 
+//!
 //! #### as serde_json::Value
 //! ```rust
 //! let msg = serde_json::json!({
@@ -29,7 +30,6 @@
 //! });
 //! let msg_id = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
 //! ```
-
 //! #### as a struct
 //! ```rust
 //! use serde::{Serialize, Deserialize};
@@ -42,16 +42,15 @@
 //! };
 //! let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
 //! ```
-
+//!
 //! ## Reading messages
 //! Reading a message will make it invisible for the duration of the visibility timeout (vt).
 //! No messages are returned when the queue is empty or all messages are invisible.
-//! Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>` 
-//! where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct. 
-//! Note that when parsing into a `struct`, the application will panic if the message cannot be 
-//! parsed as the type specified. For example, if the message expected is 
+//! Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>`
+//! where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct.
+//! Note that when parsing into a `struct`, the application will panic if the message cannot be
+//! parsed as the type specified. For example, if the message expected is
 //! `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
-
 //! #### as serde_json::Value
 //! ```rust
 //! use serde_json::Value;
@@ -67,11 +66,12 @@
 //! let read_msg: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 //! ```
 //! ## Delete a message
-//!Remove the message from the queue when you are done with it.
+//! Remove the message from the queue when you are done with it.
 //! ```rust
 //! let deleted = queue.delete(&read_msg.msg_id).await;
 //! ```
 
+#![doc(html_root_url = "https://docs.rs/pgmq/")]
 
 use serde::{Deserialize, Serialize};
 use sqlx::error::Error;

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! A lightweight messaging queue for Rust, using Postgres as the backend.
 //! Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
-//! 
+//!
 //! # Examples
 //!
 //! First, start any Postgres instance. It is the only external dependency.


### PR DESCRIPTION
- docs at https://docs.rs/pgmq should build and update based on the contained documentation in `lib.rs`
- `readme.md` (in this repo) content is generated using `Make update.readme`. It's identical what's in `lib.rs` and `docs.rs`

Also updates links and metadata in `Cargo.toml`