### PR TITLE
run doc tests

### DIFF
--- a/.github/workflows/pgmq.yml
+++ b/.github/workflows/pgmq.yml
@@ -47,12 +47,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
-      - name: unit-tests
-        run: cargo test --lib
-      - name: doc-tests
-        run: cargo test --doc
-      - name: integration-tests
-        run: make test.integration
+      - name: run all tests
+        run: make test
       - name: teardown
         run: make test.cleanup
 

--- a/.github/workflows/pgmq.yml
+++ b/.github/workflows/pgmq.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: unit-tests
         run: cargo test --lib
+      - name: doc-tests
+        run: cargo test --doc
       - name: integration-tests
         run: make test.integration
       - name: teardown

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://www.coredb.io"
 keywords = ["messaging", "queues", "postgres"]
 license = "MIT"
 readme = "README.md"
-repo = "https://github.com/CoreDB-io/coredb/tree/main/crates/pgmq"
+repository = "https://github.com/CoreDB-io/coredb/tree/main/crates/pgmq"
 
 [dependencies]
 chrono = { version = "0.4.23", features = [ "serde" ] }

--- a/crates/pgmq/Makefile
+++ b/crates/pgmq/Makefile
@@ -9,9 +9,10 @@ update.readme:
 run.docker:
 	docker run --rm -d --name postgres -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 postgres:15.1
 
-test.integration: run.docker
+test: run.docker
 	sleep 2;
-	cargo test --test integration_test
+	echo "Running all tests..."
+	cargo test
 
 test.cleanup:
 	docker stop postgres

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -45,9 +45,11 @@ async fn main() {
     // READ A MESSAGE as `serde_json::Value`
     let vt: u32 = 30;
     let read_msg1: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+    assert_eq!(read_msg1.msg_id, msg_id1);
 
     // READ A MESSAGE as a struct
     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+    assert_eq!(read_msg2.msg_id, msg_id2);
 
     // DELETE THE MESSAGE WE SENT
     let deleted = queue.delete(&myqueue, &read_msg1.msg_id).await.expect("Failed to delete message");

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -22,7 +22,7 @@ use serde_json::Value;
 #[tokio::main]
 async fn main() {
     // CREATE A QUEUE
-    let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+    let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await;
     let myqueue = "myqueue".to_owned();
     queue.create(&myqueue).await.expect("Failed to create queue");
 
@@ -50,10 +50,10 @@ async fn main() {
     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 
     // DELETE THE MESSAGE WE SENT
-    let deleted = queue.delete(&read_msg1.msg_id).await.expect("Failed to delete message");
-    let deleted = queue.delete(&read_msg2.msg_id).await.expect("Failed to delete message");
+    let deleted = queue.delete(&myqueue, &read_msg1.msg_id).await.expect("Failed to delete message");
+    let deleted = queue.delete(&myqueue, &read_msg2.msg_id).await.expect("Failed to delete message");
 }
-
+```
 ## Sending messages
 
 `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -10,66 +10,69 @@ First, start any Postgres instance. It is the only external dependency.
 ```bash
 docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 ```
-## Create a queue
+
+Example of sending, receiving, and deleting messages from the queue. Typically applications sending messages
+will not be the same application reading the message.
 
 ```rust
 use pgmq::{Message, PGMQueue};
-let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+use serde::{Serialize, Deserialize};
+use serde_json::Value;
 
-let myqueue = "myqueue".to_owned();
-queue.create(&myqueue).await.expect("Failed to create queue");
-```
+#[tokio::main]
+async fn main() {
+    // CREATE A QUEUE
+    let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+    let myqueue = "myqueue".to_owned();
+    queue.create(&myqueue).await.expect("Failed to create queue");
+
+    // SEND A `serde_json::Value` MESSAGE
+    let msg1 = serde_json::json!({
+        "foo": "bar"
+    });
+    let msg_id1: i64 = queue.enqueue(&myqueue, &msg1).await.expect("Failed to enqueue message");
+
+    // SEND A STRUCT
+    #[derive(Serialize, Debug, Deserialize)]
+    struct MyMessage {
+        foo: String,
+    }
+    let msg2 = MyMessage {
+        foo: "bar".to_owned(),
+    };
+    let msg_id2: i64  = queue.enqueue(&myqueue, &msg2).await.expect("Failed to enqueue message");
+
+    // READ A MESSAGE as `serde_json::Value`
+    let vt: u32 = 30;
+    let read_msg1: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+
+    // READ A MESSAGE as a struct
+    let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+
+    // DELETE THE MESSAGE WE SENT
+    let deleted = queue.delete(&read_msg1.msg_id).await.expect("Failed to delete message");
+    let deleted = queue.delete(&read_msg2.msg_id).await.expect("Failed to delete message");
+}
 
 ## Sending messages
 
 `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
 
-#### as serde_json::Value
-```rust
-let msg = serde_json::json!({
-    "foo": "bar"
-});
-let msg_id = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
-```
-#### as a struct
-```rust
-use serde::{Serialize, Deserialize};
-#[derive(Serialize, Debug, Deserialize)]
-struct MyMessage {
-    foo: String,
-}
-let msg = MyMessage {
-    foo: "bar".to_owned(),
-};
-let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
-```
-
 ## Reading messages
-Reading a message will make it invisible for the duration of the visibility timeout (vt).
+Reading a message will make it invisible (unavailable for consumption) for the duration of the visibility timeout (vt).
 No messages are returned when the queue is empty or all messages are invisible.
-Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>`
+
+Messages can be parsed as JSON or into a struct. `queue.read()` returns an `Option<Message<T>>`
 where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct.
 Note that when parsing into a `struct`, the application will panic if the message cannot be
 parsed as the type specified. For example, if the message expected is
 `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
-#### as serde_json::Value
-```rust
-use serde_json::Value;
-let vt: u32 = 30;
-let read_msg: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-```
+
 #### as a Struct
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
 No messages are returned when the queue is empty or all messages are invisible.
-```rust
-use serde_json::Value;
-let vt: u32 = 30;
-let read_msg: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-```
+
 ## Delete a message
 Remove the message from the queue when you are done with it.
-```rust
-let deleted = queue.delete(&read_msg.msg_id).await;
-```
 
 License: MIT

--- a/crates/pgmq/examples/basic/Cargo.lock
+++ b/crates/pgmq/examples/basic/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pgmq"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "serde",

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -10,67 +10,70 @@
 //! ```bash
 //! docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
 //! ```
-//! ## Create a queue
 //!
+//! Example of sending, receiving, and deleting messages from the queue. Typically applications sending messages
+//! will not be the same application reading the message.
+//! 
 //! ```rust
 //! use pgmq::{Message, PGMQueue};
-//! let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+//! use serde::{Serialize, Deserialize};
+//! use serde_json::Value;
 //!
-//! let myqueue = "myqueue".to_owned();
-//! queue.create(&myqueue).await.expect("Failed to create queue");
-//! ```
+//! #[tokio::main]
+//! async fn main() {
+//!     // CREATE A QUEUE
+//!     let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+//!     let myqueue = "myqueue".to_owned();
+//!     queue.create(&myqueue).await.expect("Failed to create queue");
 //!
+//!     // SEND A `serde_json::Value` MESSAGE
+//!     let msg1 = serde_json::json!({
+//!         "foo": "bar"
+//!     });
+//!     let msg_id1: i64 = queue.enqueue(&myqueue, &msg1).await.expect("Failed to enqueue message");
+//!
+//!     // SEND A STRUCT
+//!     #[derive(Serialize, Debug, Deserialize)]
+//!     struct MyMessage {
+//!         foo: String,
+//!     }
+//!     let msg2 = MyMessage {
+//!         foo: "bar".to_owned(),
+//!     };
+//!     let msg_id2: i64  = queue.enqueue(&myqueue, &msg2).await.expect("Failed to enqueue message");
+//!     
+//!     // READ A MESSAGE as `serde_json::Value`
+//!     let vt: u32 = 30;
+//!     let read_msg1: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+//!
+//!     // READ A MESSAGE as a struct
+//!     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
+//!
+//!     // DELETE THE MESSAGE WE SENT
+//!     let deleted = queue.delete(&read_msg1.msg_id).await.expect("Failed to delete message");
+//!     let deleted = queue.delete(&read_msg2.msg_id).await.expect("Failed to delete message");
+//! }
+//! 
 //! ## Sending messages
 //!
 //! `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
 //!
-//! #### as serde_json::Value
-//! ```rust
-//! let msg = serde_json::json!({
-//!     "foo": "bar"
-//! });
-//! let msg_id = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
-//! ```
-//! #### as a struct
-//! ```rust
-//! use serde::{Serialize, Deserialize};
-//! #[derive(Serialize, Debug, Deserialize)]
-//! struct MyMessage {
-//!     foo: String,
-//! }
-//! let msg = MyMessage {
-//!     foo: "bar".to_owned(),
-//! };
-//! let msg_id: i64  = queue.enqueue(&myqueue, &msg).await.expect("Failed to enqueue message");
-//! ```
-//!
 //! ## Reading messages
-//! Reading a message will make it invisible for the duration of the visibility timeout (vt).
+//! Reading a message will make it invisible (unavailable for consumption) for the duration of the visibility timeout (vt).
 //! No messages are returned when the queue is empty or all messages are invisible.
-//! Messages can be parsed as JSON or as into a struct. `queue.read()` returns an `Option<Message<T>>`
+//!
+//! Messages can be parsed as JSON or into a struct. `queue.read()` returns an `Option<Message<T>>`
 //! where `T` is the type of the message on the queue. It can be parsed as JSON or as a struct.
 //! Note that when parsing into a `struct`, the application will panic if the message cannot be
 //! parsed as the type specified. For example, if the message expected is
 //! `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
-//! #### as serde_json::Value
-//! ```rust
-//! use serde_json::Value;
-//! let vt: u32 = 30;
-//! let read_msg: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-//! ```
+//!
 //! #### as a Struct
 //! Reading a message will make it invisible for the duration of the visibility timeout (vt).
 //! No messages are returned when the queue is empty or all messages are invisible.
-//! ```rust
-//! use serde_json::Value;
-//! let vt: u32 = 30;
-//! let read_msg: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-//! ```
+//!
 //! ## Delete a message
 //! Remove the message from the queue when you are done with it.
-//! ```rust
-//! let deleted = queue.delete(&read_msg.msg_id).await;
-//! ```
 
 #![doc(html_root_url = "https://docs.rs/pgmq/")]
 

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! Example of sending, receiving, and deleting messages from the queue. Typically applications sending messages
 //! will not be the same application reading the message.
-//! 
+//!
 //! ```rust
 //! use pgmq::{Message, PGMQueue};
 //! use serde::{Serialize, Deserialize};
@@ -22,7 +22,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // CREATE A QUEUE
-//!     let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await.expect("Failed to connect to Postgres");
+//!     let queue: PGMQueue = PGMQueue::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned()).await;
 //!     let myqueue = "myqueue".to_owned();
 //!     queue.create(&myqueue).await.expect("Failed to create queue");
 //!
@@ -50,10 +50,10 @@
 //!     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 //!
 //!     // DELETE THE MESSAGE WE SENT
-//!     let deleted = queue.delete(&read_msg1.msg_id).await.expect("Failed to delete message");
-//!     let deleted = queue.delete(&read_msg2.msg_id).await.expect("Failed to delete message");
+//!     let deleted = queue.delete(&myqueue, &read_msg1.msg_id).await.expect("Failed to delete message");
+//!     let deleted = queue.delete(&myqueue, &read_msg2.msg_id).await.expect("Failed to delete message");
 //! }
-//! 
+//! ```
 //! ## Sending messages
 //!
 //! `queue.enqueue()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -45,10 +45,12 @@
 //!     // READ A MESSAGE as `serde_json::Value`
 //!     let vt: u32 = 30;
 //!     let read_msg1: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-//!
+//!     assert_eq!(read_msg1.msg_id, msg_id1);
+//! 
 //!     // READ A MESSAGE as a struct
 //!     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
-//!
+//!     assert_eq!(read_msg2.msg_id, msg_id2);
+//! 
 //!     // DELETE THE MESSAGE WE SENT
 //!     let deleted = queue.delete(&myqueue, &read_msg1.msg_id).await.expect("Failed to delete message");
 //!     let deleted = queue.delete(&myqueue, &read_msg2.msg_id).await.expect("Failed to delete message");

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -46,11 +46,11 @@
 //!     let vt: u32 = 30;
 //!     let read_msg1: Message<Value> = queue.read::<Value>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 //!     assert_eq!(read_msg1.msg_id, msg_id1);
-//! 
+//!
 //!     // READ A MESSAGE as a struct
 //!     let read_msg2: Message<MyMessage> = queue.read::<MyMessage>(&myqueue, Some(&vt)).await.expect("no messages in the queue!");
 //!     assert_eq!(read_msg2.msg_id, msg_id2);
-//! 
+//!
 //!     // DELETE THE MESSAGE WE SENT
 //!     let deleted = queue.delete(&myqueue, &read_msg1.msg_id).await.expect("Failed to delete message");
 //!     let deleted = queue.delete(&myqueue, &read_msg2.msg_id).await.expect("Failed to delete message");


### PR DESCRIPTION
Updated the docs so that they can be tested with `cargo test --doc`.
- the readme/doc example becomes runnable code instead of stand-alone snippets.
- change the ci workflow to run `cargo test` (test everything together), instead of unit/doc/integration tests separately. doc tests need an instance of postgres to run, and so do integration tests. only the unit tests can run alone. Its simpler to run them all together.