### PR TITLE
implement pgmq pop()

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.0.3"
+version = "0.1.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A message queue for Rust applications. The only external dependency is a Postgres database."

--- a/crates/pgmq/examples/basic/Cargo.lock
+++ b/crates/pgmq/examples/basic/Cargo.lock
@@ -772,7 +772,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pgmq"
-version = "0.0.3"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -114,7 +114,7 @@ impl PGMQueue {
         }
     }
 
-    // Connect to the database
+    /// Connect to the database
     async fn connect(url: &str) -> Pool<Postgres> {
         PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_secs(10))
@@ -124,7 +124,7 @@ impl PGMQueue {
             .expect("connection failed")
     }
 
-    // Create a queue
+    /// Create a queue
     pub async fn create(&self, queue_name: &str) -> Result<(), Error> {
         let create = query::create(queue_name);
         let index: String = query::create_index(queue_name);
@@ -133,7 +133,7 @@ impl PGMQueue {
         Ok(())
     }
 
-    // Send a message to the queue
+    /// Send a message to the queue
     pub async fn enqueue<T: Serialize>(&self, queue_name: &str, message: &T) -> Result<i64, Error> {
         let msg = &serde_json::json!(&message);
         let row: PgRow = sqlx::query(&query::enqueue(queue_name, msg))
@@ -172,7 +172,7 @@ impl PGMQueue {
         }
     }
 
-    // Delete a message from the queue
+    /// Delete a message from the queue
     pub async fn delete(&self, queue_name: &str, msg_id: &i64) -> Result<u64, Error> {
         let query = &query::delete(queue_name, msg_id);
         let row = sqlx::query(query).execute(&self.connection).await?;
@@ -188,7 +188,8 @@ impl PGMQueue {
     }
 }
 
-/// Reads a single message from the queue.
+// Executes a query and returns a single row
+// If the query returns no rows, None is returned
 async fn fetch_one<T: for<'de> Deserialize<'de>>(
     query: &str,
     connection: &Pool<Postgres>,

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -114,6 +114,7 @@ impl PGMQueue {
         }
     }
 
+    // Connect to the database
     async fn connect(url: &str) -> Pool<Postgres> {
         PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_secs(10))
@@ -123,6 +124,7 @@ impl PGMQueue {
             .expect("connection failed")
     }
 
+    // Create a queue
     pub async fn create(&self, queue_name: &str) -> Result<(), Error> {
         let create = query::create(queue_name);
         let index: String = query::create_index(queue_name);
@@ -131,6 +133,7 @@ impl PGMQueue {
         Ok(())
     }
 
+    // Send a message to the queue
     pub async fn enqueue<T: Serialize>(&self, queue_name: &str, message: &T) -> Result<i64, Error> {
         let msg = &serde_json::json!(&message);
         let row: PgRow = sqlx::query(&query::enqueue(queue_name, msg))
@@ -140,6 +143,8 @@ impl PGMQueue {
         Ok(row.try_get("msg_id").unwrap())
     }
 
+    /// Reads a single message from the queue. If the queue is empty or all messages are invisible, `None` is returned.
+    /// If a message is returned, it is made invisible for the duration of the visibility timeout (vt) in seconds.
     pub async fn read<T: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
@@ -167,6 +172,7 @@ impl PGMQueue {
         }
     }
 
+    // Delete a message from the queue
     pub async fn delete(&self, queue_name: &str, msg_id: &i64) -> Result<u64, Error> {
         let query = &query::delete(queue_name, msg_id);
         let row = sqlx::query(query).execute(&self.connection).await?;
@@ -174,12 +180,15 @@ impl PGMQueue {
         Ok(num_deleted)
     }
 
-    pub async fn pop<T: for<'de> Deserialize<'de>>(self, queue_name: &str) -> Option<Message<T>> {
+    /// Reads a single message from the queue. The message is deleted from the queue immediately.
+    /// If no messages are available, `None` is returned.
+    pub async fn pop<T: for<'de> Deserialize<'de>>(&self, queue_name: &str) -> Option<Message<T>> {
         let query = &query::pop(queue_name);
-        fetch_one::<T>(&query, &self.connection).await
+        fetch_one::<T>(query, &self.connection).await
     }
 }
 
+/// Reads a single message from the queue.
 async fn fetch_one<T: for<'de> Deserialize<'de>>(
     query: &str,
     connection: &Pool<Postgres>,
@@ -187,12 +196,12 @@ async fn fetch_one<T: for<'de> Deserialize<'de>>(
     let row: Result<PgRow, Error> = sqlx::query(query).fetch_one(connection).await;
     match row {
         Ok(row) => {
-            let b = row.get("message");
-            let a = serde_json::from_value::<T>(b).unwrap();
+            let raw_msg = row.get("message");
+            let parsed_msg = serde_json::from_value::<T>(raw_msg).expect("unable to parse message");
             Some(Message {
                 msg_id: row.get("msg_id"),
                 vt: row.get("vt"),
-                message: a,
+                message: parsed_msg,
             })
         }
         Err(_) => None,


### PR DESCRIPTION
Pop deletes a message upon reading it. This is a convenience method present in RSMQ that does have some use case - particularly when data loss is acceptable and/or load on the postgres instance is of concern (read + delete is 2 transactions with a lock. pop is a single transaction).

Also added some more documentation to the existing methods and a minor refactor to existing tests in order to reduce some code duplication.