### PR TITLE
Rename API

### DIFF
--- a/coredb-cli/src/commands/create.rs
+++ b/coredb-cli/src/commands/create.rs
@@ -17,7 +17,7 @@ fn generate_yaml(resource_type: ResourceType, name: String) -> String {
     match resource_type {
         ResourceType::Db | ResourceType::Dbs => {
             let json_value = json!({
-                "apiVersion": "coredb.io/v1",
+                "apiVersion": "coredb.io/v1alpha1",
                 "kind": "CoreDB",
                 "metadata": {
                     "name": name,

--- a/coredb-cli/src/commands/create.rs
+++ b/coredb-cli/src/commands/create.rs
@@ -17,7 +17,7 @@ fn generate_yaml(resource_type: ResourceType, name: String) -> String {
     match resource_type {
         ResourceType::Db | ResourceType::Dbs => {
             let json_value = json!({
-                "apiVersion": "kube.rs/v1",
+                "apiVersion": "coredb.io/v1",
                 "kind": "CoreDB",
                 "metadata": {
                     "name": name,

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -30,14 +30,14 @@ use std::sync::Arc;
 use tokio::{sync::RwLock, time::Duration};
 use tracing::*;
 
-pub static COREDB_FINALIZER: &str = "coredbs.kube.rs";
+pub static COREDB_FINALIZER: &str = "coredbs.coredb.io";
 
 /// Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
 ///
 /// This provides a hook for generating the CRD yaml (in crdgen.rs)
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[cfg_attr(test, derive(Default))]
-#[kube(kind = "CoreDB", group = "kube.rs", version = "v1", namespaced)]
+#[kube(kind = "CoreDB", group = "coredb.io", version = "v1", namespaced)]
 #[kube(status = "CoreDBStatus", shortname = "cdb")]
 pub struct CoreDBSpec {
     #[serde(default = "defaults::default_replicas")]
@@ -104,7 +104,7 @@ impl CoreDB {
 
         // always overwrite status object with what we saw
         let new_status = Patch::Apply(json!({
-            "apiVersion": "kube.rs/v1",
+            "apiVersion": "coredb.io/v1",
             "kind": "CoreDB",
             "status": CoreDBStatus {
                 running: true,

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -37,7 +37,7 @@ pub static COREDB_FINALIZER: &str = "coredbs.coredb.io";
 /// This provides a hook for generating the CRD yaml (in crdgen.rs)
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[cfg_attr(test, derive(Default))]
-#[kube(kind = "CoreDB", group = "coredb.io", version = "v1", namespaced)]
+#[kube(kind = "CoreDB", group = "coredb.io", version = "v1alpha1", namespaced)]
 #[kube(status = "CoreDBStatus", shortname = "cdb")]
 pub struct CoreDBSpec {
     #[serde(default = "defaults::default_replicas")]
@@ -104,7 +104,7 @@ impl CoreDB {
 
         // always overwrite status object with what we saw
         let new_status = Patch::Apply(json!({
-            "apiVersion": "coredb.io/v1",
+            "apiVersion": "coredb.io/v1alpha1",
             "kind": "CoreDB",
             "status": CoreDBStatus {
                 running: true,

--- a/coredb-operator/src/fixtures.rs
+++ b/coredb-operator/src/fixtures.rs
@@ -48,7 +48,7 @@ impl ApiServerVerifier {
             assert_eq!(
                 request.uri().to_string(),
                 format!(
-                    "/apis/coredb.io/v1/namespaces/testns/coredbs/{}?",
+                    "/apis/coredb.io/v1alpha1/namespaces/testns/coredbs/{}?",
                     coredb.name_any()
                 )
             );
@@ -80,7 +80,7 @@ impl ApiServerVerifier {
             assert_eq!(
                 request.uri().to_string(),
                 format!(
-                    "/apis/coredb.io/v1/namespaces/testns/coredbs/{}/status?&force=true&fieldManager=cntrlr",
+                    "/apis/coredb.io/v1alpha1/namespaces/testns/coredbs/{}/status?&force=true&fieldManager=cntrlr",
                     coredb.name_any()
                 )
             );

--- a/coredb-operator/src/fixtures.rs
+++ b/coredb-operator/src/fixtures.rs
@@ -48,7 +48,7 @@ impl ApiServerVerifier {
             assert_eq!(
                 request.uri().to_string(),
                 format!(
-                    "/apis/kube.rs/v1/namespaces/testns/coredbs/{}?",
+                    "/apis/coredb.io/v1/namespaces/testns/coredbs/{}?",
                     coredb.name_any()
                 )
             );
@@ -80,7 +80,7 @@ impl ApiServerVerifier {
             assert_eq!(
                 request.uri().to_string(),
                 format!(
-                    "/apis/kube.rs/v1/namespaces/testns/coredbs/{}/status?&force=true&fieldManager=cntrlr",
+                    "/apis/coredb.io/v1/namespaces/testns/coredbs/{}/status?&force=true&fieldManager=cntrlr",
                     coredb.name_any()
                 )
             );

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -25,7 +25,7 @@ mod test {
     use rand::Rng;
     use std::str;
 
-    const API_VERSION: &str = "coredb.io/v1";
+    const API_VERSION: &str = "coredb.io/v1alpha1";
 
     fn is_pod_ready() -> impl Condition<Pod> + 'static {
         move |obj: Option<&Pod>| {

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -25,7 +25,7 @@ mod test {
     use rand::Rng;
     use std::str;
 
-    const API_VERSION: &str = "kube.rs/v1";
+    const API_VERSION: &str = "coredb.io/v1";
 
     fn is_pod_ready() -> impl Condition<Pod> + 'static {
         move |obj: Option<&Pod>| {
@@ -170,7 +170,7 @@ mod test {
             std::time::Duration::from_secs(2),
             await_condition(
                 custom_resource_definitions,
-                "coredbs.kube.rs",
+                "coredbs.coredb.io",
                 conditions::is_crd_established(),
             ),
         )

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns: []
-    name: v1
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Auto-generated derived type for CoreDBSpec via `CustomResource`

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: coredbs.kube.rs
+  name: coredbs.coredb.io
 spec:
-  group: kube.rs
+  group: coredb.io
   names:
     categories: []
     kind: CoreDB

--- a/coredb-operator/yaml/install.yaml
+++ b/coredb-operator/yaml/install.yaml
@@ -14,7 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: control-cdb
 rules:
-  - apiGroups: ["kube.rs"]
+  - apiGroups: ["coredb.io"]
     resources: ["coredbs", "coredbs/status"]
     verbs:
     - get

--- a/coredb-operator/yaml/sample-coredb.yaml
+++ b/coredb-operator/yaml/sample-coredb.yaml
@@ -1,4 +1,4 @@
-apiVersion: coredb.io/v1
+apiVersion: coredb.io/v1alpha1
 kind: CoreDB
 metadata:
   name: sample-coredb

--- a/coredb-operator/yaml/sample-coredb.yaml
+++ b/coredb-operator/yaml/sample-coredb.yaml
@@ -1,4 +1,4 @@
-apiVersion: kube.rs/v1
+apiVersion: coredb.io/v1
 kind: CoreDB
 metadata:
   name: sample-coredb


### PR DESCRIPTION
We have the API named unintentionally. It was just set as the default name in the kube-rs controller example. Instead, the API should be named to our domain.