### PR TITLE
[COR-159] Enable extensions provided in spec

### DIFF
--- a/coredb-operator/Cargo.lock
+++ b/coredb-operator/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "passwords",
  "prometheus",
  "rand",
+ "regex",
  "schemars",
  "serde",
  "serde_json",
@@ -1877,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/coredb-operator/Cargo.toml
+++ b/coredb-operator/Cargo.toml
@@ -43,6 +43,7 @@ opentelemetry-otlp = { version = "0.11.0", features = ["tokio"], optional = true
 tonic = { version = "0.8.3", optional = true }
 thiserror = "1.0.37"
 passwords = "3.1.12"
+regex = "1.7.1"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -48,6 +48,7 @@ pub struct CoreDBSpec {
     pub port: i32,
     #[serde(default = "defaults::default_uid")]
     pub uid: i32,
+    pub enabledExtensions: Vec<String>
 }
 
 /// The status object of `CoreDB`

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -49,7 +49,7 @@ pub struct CoreDBSpec {
     #[serde(default = "defaults::default_uid")]
     pub uid: i32,
     #[serde(default = "defaults::default_extensions")]
-    pub enabledExtensions: Vec<String>
+    pub enabledExtensions: Vec<String>,
 }
 
 /// The status object of `CoreDB`

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -22,7 +22,7 @@ use kube::{
     CustomResource, Resource,
 };
 
-use crate::{controller_util::create_extensions, secret::reconcile_secret};
+use crate::{extensions::create_extensions, secret::reconcile_secret};
 use k8s_openapi::api::core::v1::Pod;
 use kube::runtime::wait::{await_condition, conditions, Condition};
 use schemars::JsonSchema;
@@ -41,6 +41,7 @@ pub static COREDB_FINALIZER: &str = "coredbs.coredb.io";
 #[cfg_attr(test, derive(Default))]
 #[kube(kind = "CoreDB", group = "coredb.io", version = "v1alpha1", namespaced)]
 #[kube(status = "CoreDBStatus", shortname = "cdb")]
+#[allow(non_snake_case)]
 pub struct CoreDBSpec {
     #[serde(default = "defaults::default_replicas")]
     pub replicas: i32,

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -48,6 +48,7 @@ pub struct CoreDBSpec {
     pub port: i32,
     #[serde(default = "defaults::default_uid")]
     pub uid: i32,
+    #[serde(default = "defaults::default_extensions")]
     pub enabledExtensions: Vec<String>
 }
 

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -22,7 +22,7 @@ use kube::{
     CustomResource, Resource,
 };
 
-use crate::secret::reconcile_secret;
+use crate::{controller_util::create_extensions, secret::reconcile_secret};
 use k8s_openapi::api::core::v1::Pod;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -133,6 +133,11 @@ impl CoreDB {
         reconcile_svc(self, ctx.clone())
             .await
             .expect("error reconciling service");
+
+        // create extensions
+        create_extensions(self, &ctx)
+            .await
+            .expect("error creating extensions");
 
         // If no events were received, check back every minute
         Ok(Action::requeue(Duration::from_secs(60)))

--- a/coredb-operator/src/controller_util.rs
+++ b/coredb-operator/src/controller_util.rs
@@ -6,8 +6,7 @@ pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), E
     let client = &ctx.client;
     let extensions = &cdb.spec.enabledExtensions;
 
-    // iterate through list of extensions and run CREATE EXTENSION <extension-name>
-    // TODO(ianstanton) we need to check if the extensions are enabled before creating them
+    // iterate through list of extensions and run CREATE EXTENSION <extension-name> for each
     for ext in extensions {
         info!("Creating extension: {}", ext);
         let result = cdb

--- a/coredb-operator/src/controller_util.rs
+++ b/coredb-operator/src/controller_util.rs
@@ -1,0 +1,24 @@
+use crate::{Context, CoreDB, Error};
+use std::sync::{atomic::compiler_fence, Arc};
+use tracing::info;
+
+pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Error> {
+    let client = &ctx.client;
+    let extensions = &cdb.spec.enabledExtensions;
+
+    // iterate through list of extensions and run CREATE EXTENSION <extension-name>
+    // TODO(ianstanton) we need to check if the extensions are enabled before creating them
+    for ext in extensions {
+        info!("Creating extension: {}", ext);
+        let result = cdb
+            .psql(
+                format!("CREATE EXTENSION {};", ext),
+                "postgres".to_owned(),
+                client.clone(),
+            )
+            .await
+            .unwrap();
+        println!("Result: {}", result.stdout.clone().unwrap());
+    }
+    Ok(())
+}

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -14,4 +14,6 @@ pub fn default_image() -> String {
     "docker.io/postgres:15".to_owned()
 }
 
-pub fn default_extensions() -> Vec<String> {vec![]}
+pub fn default_extensions() -> Vec<String> {
+    vec![]
+}

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -13,3 +13,5 @@ pub fn default_port() -> i32 {
 pub fn default_image() -> String {
     "docker.io/postgres:15".to_owned()
 }
+
+pub fn default_extensions() -> Vec<String> {vec![]}

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -1,5 +1,5 @@
 use crate::{Context, CoreDB, Error};
-use std::sync::{atomic::compiler_fence, Arc};
+use std::sync::Arc;
 use tracing::info;
 
 pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Error> {

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -1,27 +1,33 @@
 use crate::{Context, CoreDB, Error};
 use std::sync::Arc;
 use tracing::debug;
+use regex::Regex;
 
 pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Error> {
     let client = &ctx.client;
     let extensions = &cdb.spec.enabledExtensions;
+    let re = Regex::new(r"[a-zA-Z][0-9a-zA-Z_-]*$").unwrap();
 
     // TODO(ianstanton) Some extensions will fail to create. We need to handle and surface any errors.
     //  Logging result at debug level for now.
 
     // iterate through list of extensions and run CREATE EXTENSION <extension-name> for each
     for ext in extensions {
-        debug!("Creating extension: {}", ext);
-        // this will no-op if we've already created the extension
-        let result = cdb
-            .psql(
-                format!("CREATE EXTENSION {};", ext),
-                "postgres".to_owned(),
-                client.clone(),
-            )
-            .await
-            .unwrap();
-        debug!("Result: {}", result.stdout.clone().unwrap());
+        if !re.is_match(ext) {
+            debug!("Extension {} is not formatted properly. Skipping creation.", ext)
+        } else {
+            debug!("Creating extension: {}", ext);
+            // this will no-op if we've already created the extension
+            let result = cdb
+                .psql(
+                    format!("CREATE EXTENSION {};", ext),
+                    "postgres".to_owned(),
+                    client.clone(),
+                )
+                .await
+                .unwrap();
+            debug!("Result: {}", result.stdout.clone().unwrap());
+        }
     }
     Ok(())
 }

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -1,14 +1,18 @@
 use crate::{Context, CoreDB, Error};
 use std::sync::Arc;
-use tracing::info;
+use tracing::debug;
 
 pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Error> {
     let client = &ctx.client;
     let extensions = &cdb.spec.enabledExtensions;
 
+    // TODO(ianstanton) Some extensions will fail to create. We need to handle and surface any errors.
+    //  Logging result at debug level for now.
+
     // iterate through list of extensions and run CREATE EXTENSION <extension-name> for each
     for ext in extensions {
-        info!("Creating extension: {}", ext);
+        debug!("Creating extension: {}", ext);
+        // this will no-op if we've already created the extension
         let result = cdb
             .psql(
                 format!("CREATE EXTENSION {};", ext),
@@ -17,7 +21,7 @@ pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), E
             )
             .await
             .unwrap();
-        println!("Result: {}", result.stdout.clone().unwrap());
+        debug!("Result: {}", result.stdout.clone().unwrap());
     }
     Ok(())
 }

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -1,7 +1,7 @@
 use crate::{Context, CoreDB, Error};
+use regex::Regex;
 use std::sync::Arc;
 use tracing::debug;
-use regex::Regex;
 
 pub async fn create_extensions(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Error> {
     let client = &ctx.client;

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -9,12 +9,14 @@ pub mod telemetry;
 mod metrics;
 pub use metrics::Metrics;
 
+mod controller_util;
 mod defaults;
 #[cfg(test)] pub mod fixtures;
 mod psql;
 mod secret;
 mod service;
 mod statefulset;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -9,8 +9,8 @@ pub mod telemetry;
 mod metrics;
 pub use metrics::Metrics;
 
-mod controller_util;
 mod defaults;
+mod extensions;
 #[cfg(test)] pub mod fixtures;
 mod psql;
 mod secret;

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -16,7 +16,6 @@ mod psql;
 mod secret;
 mod service;
 mod statefulset;
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -25,11 +25,27 @@ spec:
 
               This provides a hook for generating the CRD yaml (in crdgen.rs)
             properties:
+              enabledExtensions:
+                items:
+                  type: string
+                type: array
+              image:
+                default: docker.io/postgres:15
+                type: string
+              port:
+                default: 5432
+                format: int32
+                type: integer
               replicas:
+                default: 1
+                format: int32
+                type: integer
+              uid:
+                default: 999
                 format: int32
                 type: integer
             required:
-            - replicas
+            - enabledExtensions
             type: object
           status:
             description: The status object of `CoreDB`

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -26,6 +26,7 @@ spec:
               This provides a hook for generating the CRD yaml (in crdgen.rs)
             properties:
               enabledExtensions:
+                default: []
                 items:
                   type: string
                 type: array
@@ -44,8 +45,6 @@ spec:
                 default: 999
                 format: int32
                 type: integer
-            required:
-            - enabledExtensions
             type: object
           status:
             description: The status object of `CoreDB`

--- a/coredb-operator/yaml/sample-coredb.yaml
+++ b/coredb-operator/yaml/sample-coredb.yaml
@@ -4,3 +4,5 @@ metadata:
   name: sample-coredb
 spec:
   replicas: 1
+  enabledExtensions:
+    - postgis


### PR DESCRIPTION
Add extension creation based on extensions specified in spec value `enabledExtensions`.
Example spec:
```
apiVersion: coredb.io/v1alpha1
kind: CoreDB
metadata:
  name: sample-coredb
spec:
  replicas: 1
  enabledExtensions:
    - pgmq
    - postgis
```

We'll iterate through this list and run `CREATE EXTENSION <extension-name>;` for each extension. This command will no-op if we've already created the extension.