### PR TITLE
Use consistent format for verbs

### DIFF
--- a/coredb-operator/yaml/install.yaml
+++ b/coredb-operator/yaml/install.yaml
@@ -16,11 +16,7 @@ metadata:
 rules:
   - apiGroups: ["coredb.io"]
     resources: ["coredbs", "coredbs/status"]
-    verbs:
-    - get
-    - watch
-    - list
-    - patch
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]


### PR DESCRIPTION
Clean up format of verbs in ClusterRole rules.