### PR TITLE
add archive + destroy queue

### DIFF
--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -3,7 +3,7 @@
 A lightweight messaging queue for Rust, using Postgres as the backend.
 Inspired by the [RSMQ project](https://github.com/smrchy/rsmq).
 
-# Examples
+## Examples
 
 First, start any Postgres instance. It is the only external dependency.
 
@@ -60,11 +60,13 @@ async fn main() {
     assert!(no_msg.is_none());
 }
 ```
+
 ## Sending messages
 
 `queue.send()` can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
 
 ## Reading messages
+
 Reading a message will make it invisible (unavailable for consumption) for the duration of the visibility timeout (vt).
 No messages are returned when the queue is empty or all messages are invisible.
 
@@ -74,11 +76,8 @@ Note that when parsing into a `struct`, the operation will return an error if
 parsed as the type specified. For example, if the message expected is
 `MyMessage{foo: "bar"}` but` {"hello": "world"}` is received, the application will panic.
 
-#### as a Struct
-Reading a message will make it invisible for the duration of the visibility timeout (vt).
-No messages are returned when the queue is empty or all messages are invisible.
-
 ## Archive or Delete a message
+
 Remove the message from the queue when you are done with it. You can either completely `.delete()`, or `.archive()` the message. Archived messages are deleted from the queue and inserted to the queue's archive table. Deleted messages are just deleted.
 
 License: MIT

--- a/crates/pgmq/README.md
+++ b/crates/pgmq/README.md
@@ -78,7 +78,7 @@ parsed as the type specified. For example, if the message expected is
 Reading a message will make it invisible for the duration of the visibility timeout (vt).
 No messages are returned when the queue is empty or all messages are invisible.
 
-## Delete a message
-Remove the message from the queue when you are done with it.
+## Archive or Delete a message
+Remove the message from the queue when you are done with it. You can either completely `.delete()`, or `.archive()` the message. Archived messages are deleted from the queue and inserted to the queue's archive table. Deleted messages are just deleted.
 
 License: MIT

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -193,7 +193,6 @@ impl PGMQueue {
     /// move message from queue table to archive table
     pub async fn archive(&self, queue_name: &str, msg_id: &i64) -> Result<u64, Error> {
         let query = query::archive(queue_name, msg_id);
-        println!("archive query: {}", query);
         let row = sqlx::query(&query).execute(&self.connection).await?;
         let num_deleted = row.rows_affected();
         Ok(num_deleted)

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -193,6 +193,7 @@ impl PGMQueue {
     /// move message from queue table to archive table
     pub async fn archive(&self, queue_name: &str, msg_id: &i64) -> Result<u64, Error> {
         let query = query::archive(queue_name, msg_id);
+        println!("archive query: {}", query);
         let row = sqlx::query(&query).execute(&self.connection).await?;
         let num_deleted = row.rows_affected();
         Ok(num_deleted)

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -10,6 +10,15 @@ pub fn init_queue(name: &str) -> Vec<String> {
     ]
 }
 
+pub fn destory_queue(name: &str) -> Vec<String> {
+    vec![
+        drop_queue(name),
+        delete_queue_index(name),
+        drop_queue_archive(name),
+        delete_queue_metadata(name),
+    ]
+}
+
 pub fn create_queue(name: &str) -> String {
     format!(
         "
@@ -46,6 +55,40 @@ pub fn create_meta() -> String {
             queue_name VARCHAR UNIQUE,
             created_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc')
         );
+        "
+    )
+}
+
+pub fn drop_queue(name: &str) -> String {
+    format!(
+        "
+        DROP TABLE IF EXISTS {TABLE_PREFIX}_{name};
+        "
+    )
+}
+
+pub fn delete_queue_index(name: &str) -> String {
+    format!(
+        "
+        DROP INDEX IF EXISTS vt_idx_{name};
+        "
+    )
+}
+
+pub fn delete_queue_metadata(name: &str) -> String {
+    format!(
+        "
+        DELETE
+        FROM {TABLE_PREFIX}_meta
+        WHERE queue_name = '{name}';
+        "
+    )
+}
+
+pub fn drop_queue_archive(name: &str) -> String {
+    format!(
+        "
+        DROP TABLE IF EXISTS {TABLE_PREFIX}_{name}_archive;
         "
     )
 }
@@ -124,9 +167,14 @@ pub fn delete(name: &str, msg_id: &i64) -> String {
 pub fn archive(name: &str, msg_id: &i64) -> String {
     format!(
         "
+        WITH archived AS (
+            DELETE FROM {TABLE_PREFIX}_{name}
+            WHERE msg_id = {msg_id};
+            RETURNING *
+        )
         INSERT INTO {TABLE_PREFIX}_{name}_archive
-        SELECT * FROM {TABLE_PREFIX}_{name}
-        WHERE msg_id = {msg_id};
+        SELECT *
+        FROM archived;
         "
     )
 }

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -78,9 +78,18 @@ pub fn delete_queue_index(name: &str) -> String {
 pub fn delete_queue_metadata(name: &str) -> String {
     format!(
         "
-        DELETE
-        FROM {TABLE_PREFIX}_meta
-        WHERE queue_name = '{name}';
+        DO $$
+        BEGIN
+           IF EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_name = '{TABLE_PREFIX}_meta')
+            THEN
+              DELETE
+              FROM {TABLE_PREFIX}_meta
+              WHERE queue_name = '{name}';
+           END IF;
+        END $$;
         "
     )
 }

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -70,7 +70,7 @@ pub fn drop_queue(name: &str) -> String {
 pub fn delete_queue_index(name: &str) -> String {
     format!(
         "
-        DROP INDEX IF EXISTS vt_idx_{name};
+        DROP INDEX IF EXISTS {TABLE_PREFIX}_{name}.vt_idx_{name};
         "
     )
 }
@@ -169,11 +169,11 @@ pub fn archive(name: &str, msg_id: &i64) -> String {
         "
         WITH archived AS (
             DELETE FROM {TABLE_PREFIX}_{name}
-            WHERE msg_id = {msg_id};
-            RETURNING *
+            WHERE msg_id = {msg_id}
+            RETURNING msg_id, vt, read_ct, enqueued_at, message
         )
-        INSERT INTO {TABLE_PREFIX}_{name}_archive
-        SELECT *
+        INSERT INTO {TABLE_PREFIX}_{name}_archive (msg_id, vt, read_ct, enqueued_at, message)
+        SELECT msg_id, vt, read_ct, enqueued_at, message 
         FROM archived;
         "
     )


### PR DESCRIPTION
- implements the `.archive()` method. This essentially moves the message from the queue table to the archive table, instead of outright deleting it.
- implements the `.destroy()` method. This deletes the queue table and its index, archive table, and deletes the queue record from `pgmq_meta` table. It might be safer for this to live in an "admin" API long term, instead of the "Queue" API. However, right now there is no admin API 😸 

and adds tests for both of these