### PR TITLE
Add DatabaseError Test to `pgmq`

### DIFF
--- a/extensions/pgx_pgmq/Cargo.toml
+++ b/extensions/pgx_pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgx_pgmq"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"

--- a/extensions/pgx_pgmq/Cargo.toml
+++ b/extensions/pgx_pgmq/Cargo.toml
@@ -25,7 +25,7 @@ pg_test = []
 [dependencies]
 pgx = "0.7.1"
 serde = "1.0.152"
-pgmq = { path = "../../crates/pgmq", version = "0.3.0" }
+pgmq = { path = "../../crates/pgmq", version = "0.4.0" }
 serde_json = "1.0.91"
 
 [dev-dependencies]


### PR DESCRIPTION
This test was replaced in https://github.com/CoreDB-io/coredb/pull/84. Adding it back to the test suite.