### PR TITLE
add message metadata

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A message queue for Rust applications. The only external dependency is a Postgres database."

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -118,7 +118,7 @@ pub struct Message<T = serde_json::Value> {
     #[serde(deserialize_with = "from_ts")]
     pub vt: chrono::DateTime<Utc>,
     pub enqueued_at: chrono::DateTime<Utc>,
-    pub read_ct: i64,
+    pub read_ct: i32,
     pub message: T,
 }
 

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -117,6 +117,8 @@ pub struct Message<T = serde_json::Value> {
     pub msg_id: i64,
     #[serde(deserialize_with = "from_ts")]
     pub vt: chrono::DateTime<Utc>,
+    pub enqueued_at: chrono::DateTime<Utc>,
+    pub read_ct: i64,
     pub message: T,
 }
 
@@ -263,6 +265,8 @@ async fn fetch_one_message<T: for<'de> Deserialize<'de>>(
                 Ok(parsed_msg) => Ok(Some(Message {
                     msg_id: row.get("msg_id"),
                     vt: row.get("vt"),
+                    read_ct: row.get("read_ct"),
+                    enqueued_at: row.get("enqueued_at"),
                     message: parsed_msg,
                 })),
                 Err(e) => Err(errors::PgmqError::JsonParsingError(e)),
@@ -296,6 +300,8 @@ async fn fetch_messages<T: for<'de> Deserialize<'de>>(
                 messages.push(Message {
                     msg_id: row.get("msg_id"),
                     vt: row.get("vt"),
+                    read_ct: row.get("read_ct"),
+                    enqueued_at: row.get("enqueued_at"),
                     message: parsed_msg,
                 })
             }


### PR DESCRIPTION
`enqueued_at` and `read_ct` should be part of the `Message` envelope and probably should have gone out with https://github.com/CoreDB-io/coredb/pull/78.