### PR TITLE
rename pgmq extension

### DIFF
--- a/extensions/pgx_pgmq/Cargo.lock
+++ b/extensions/pgx_pgmq/Cargo.lock
@@ -1151,9 +1151,20 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.5.1"
+version = "0.0.4"
+dependencies = [
+ "pgmq 0.7.2",
+ "pgx",
+ "pgx-tests",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pgmq"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004bb81cb9259aa4ace7e22968159f54bc1a3c54b2225e532840d25322c89a4d"
+checksum = "e717f52a46868d3a34e3f9d9984319978fcc73b63febd71d87b336a335c2d416"
 dependencies = [
  "chrono",
  "log",
@@ -1284,17 +1295,6 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "time 0.3.17",
-]
-
-[[package]]
-name = "pgx_pgmq"
-version = "0.0.4"
-dependencies = [
- "pgmq",
- "pgx",
- "pgx-tests",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/extensions/pgx_pgmq/Cargo.toml
+++ b/extensions/pgx_pgmq/Cargo.toml
@@ -25,7 +25,7 @@ pg_test = []
 [dependencies]
 pgx = "0.7.1"
 serde = "1.0.152"
-pgmq = "0.7.0"
+pgmq_crate = { package = "pgmq", version = "0.7.0" }
 serde_json = "1.0.91"
 
 [dev-dependencies]

--- a/extensions/pgx_pgmq/Cargo.toml
+++ b/extensions/pgx_pgmq/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pgx_pgmq"
+name = "pgmq"
 version = "0.0.4"
 edition = "2021"
 authors = ["CoreDB.io"]
@@ -25,7 +25,7 @@ pg_test = []
 [dependencies]
 pgx = "0.7.1"
 serde = "1.0.152"
-pgmq = "0.5.1"
+pgmq = "0.7.0"
 serde_json = "1.0.91"
 
 [dev-dependencies]

--- a/extensions/pgx_pgmq/Cargo.toml
+++ b/extensions/pgx_pgmq/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://www.coredb.io"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/CoreDB-io/coredb"
-
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/extensions/pgx_pgmq/README.md
+++ b/extensions/pgx_pgmq/README.md
@@ -103,7 +103,7 @@ pgmq=# SELECT * from pgmq_read('my_queue', 30, 2);
 If the queue is empty, or if all messages are currently invisible, no rows will be returned.
 
 ```sql
-pgx_pgmq=# SELECT * from pgmq_read('my_queue', 30, 1);
+pgmq=# SELECT * from pgmq_read('my_queue', 30, 1);
  msg_id | read_ct | vt | enqueued_at | message
 --------+---------+----+-------------+---------
 ```

--- a/extensions/pgx_pgmq/build-extension.sh
+++ b/extensions/pgx_pgmq/build-extension.sh
@@ -5,7 +5,7 @@ set -xe
 # This script is for running the action .github/actions/build-extension-package locally
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-THIS_DIR=${GIT_ROOT}/extensions/pgx_pgmq
+THIS_DIR=${GIT_ROOT}/extensions/pgmq
 
 # Cleanup files created by this script
 function cleanup {
@@ -24,7 +24,7 @@ docker build . --build-arg UBUNTU_VERSION="22.04" \
                --build-arg PGX_VERSION=0.7.1 \
                --build-arg PACKAGE_VERSION=0.0.1 \
                --build-arg NAME=pgmq \
-               --build-arg PACKAGE_NAME=pgx_pgmq \
+               --build-arg PACKAGE_NAME=pgmq \
                --build-arg PGVERSION=15 \
                -t ${random_tag}
 docker run -v $(pwd):/output ${random_tag}

--- a/extensions/pgx_pgmq/examples/python.py
+++ b/extensions/pgx_pgmq/examples/python.py
@@ -9,7 +9,7 @@ engine = create_engine("postgresql://postgres:postgres@0.0.0.0:5432/postgres")
 # create extension
 with engine.connect() as con:
     # create extension
-    created = con.execute(text( "create extension if not exists pgx_pgmq;"))
+    created = con.execute(text( "create extension if not exists pgmq;"))
     con.commit()
 
 QUEUE_NAME = 'myqueue'

--- a/extensions/pgx_pgmq/pgmq.control
+++ b/extensions/pgx_pgmq/pgmq.control
@@ -1,0 +1,5 @@
+comment = 'pgmq:  Created by pgx'
+default_version = '@CARGO_VERSION@'
+module_pathname = '$libdir/pgmq'
+relocatable = false
+superuser = false

--- a/extensions/pgx_pgmq/pgx_pgmq.control
+++ b/extensions/pgx_pgmq/pgx_pgmq.control
@@ -1,5 +1,0 @@
-comment = 'pgx_pgmq:  Created by pgx'
-default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/pgx_pgmq'
-relocatable = false
-superuser = false

--- a/extensions/pgx_pgmq/src/lib.rs
+++ b/extensions/pgx_pgmq/src/lib.rs
@@ -4,7 +4,7 @@ use pgx::warning;
 
 pgx::pg_module_magic!();
 
-use pgmq::query::{delete, enqueue_str, init_queue, pop, read};
+use pgmq_crate::query::{delete, enqueue_str, init_queue, pop, read};
 
 #[pg_extern]
 fn pgmq_create(queue_name: &str) -> Result<(), spi::Error> {
@@ -208,7 +208,7 @@ fn listit() -> Result<Vec<(String, TimestampWithTimeZone)>, spi::Error> {
 #[pg_schema]
 mod tests {
     use crate::*;
-    use pgmq::query::TABLE_PREFIX;
+    use pgmq_crate::query::TABLE_PREFIX;
     // use pgx::prelude::*;
     #[pg_test]
     fn test_create() {


### PR DESCRIPTION
Drop the `pgx` prefix from the extension name. We're using `pgx` to build the extension but I don't think we should include it in the name.