### PR TITLE
pgmq result over panic

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -20,13 +20,13 @@ thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"
 url = "2.3.1"
-regex = "1.7.1"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 cargo-readme = "3.2.0"
 criterion = "0.4"
 rand = "0.8.5"
+regex = "1.5.4"
+lazy_static = "1.4.0"
 
 [[bench]]
 name = "parsing"

--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -25,4 +25,9 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 cargo-readme = "3.2.0"
+criterion = "0.4"
 rand = "0.8.5"
+
+[[bench]]
+name = "parsing"
+harness = false

--- a/crates/pgmq/benches/parsing.rs
+++ b/crates/pgmq/benches/parsing.rs
@@ -1,0 +1,18 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use criterion::BenchmarkId;
+use pgmq::query::check_input;
+
+fn check_bytes(input: &str) -> bool {}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("check bytes", |b| {
+        b.iter(|| check_bytes(black_box("myqueue_123_longername")))
+    });
+    c.bench_function("check regex", |b| {
+        b.iter(|| check_input(black_box("myqueue_123_longername")))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/pgmq/benches/parsing.rs
+++ b/crates/pgmq/benches/parsing.rs
@@ -1,16 +1,24 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use criterion::BenchmarkId;
+use lazy_static::lazy_static;
 use pgmq::query::check_input;
+use regex::Regex;
 
-fn check_bytes(input: &str) -> bool {}
+pub fn check_regex(input: &str) {
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r#"^[a-zA-Z0-9_]+$"#).unwrap();
+    }
+    if !RE.is_match(input) {
+        panic!("Invalid queue name: {input}")
+    }
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("check bytes", |b| {
-        b.iter(|| check_bytes(black_box("myqueue_123_longername")))
+        b.iter(|| check_input(black_box("myqueue_123_longername")))
     });
     c.bench_function("check regex", |b| {
-        b.iter(|| check_input(black_box("myqueue_123_longername")))
+        b.iter(|| check_regex(black_box("myqueue_123_longername")))
     });
 }
 

--- a/crates/pgmq/src/errors.rs
+++ b/crates/pgmq/src/errors.rs
@@ -15,4 +15,9 @@ pub enum PgmqError {
     /// a database error
     #[error("database error {0}")]
     DatabaseError(#[from] sqlx::Error),
+
+    /// a queue name error
+    /// queue names must be alphanumeric and start with a letter
+    #[error("naming error: {name}")]
+    InvalidQueueName { name: String },
 }

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -272,9 +272,9 @@ mod tests {
             "foo": "bar"
         });
         msgs.push(msg);
-        let query = enqueue("yolo", &msgs);
-        assert!(query.unwrap().contains("pgmq_yolo"));
-        assert!(query.unwrap().contains("{\"foo\":\"bar\"}"));
+        let query = enqueue("yolo", &msgs).unwrap();
+        assert!(query.contains("pgmq_yolo"));
+        assert!(query.contains("{\"foo\":\"bar\"}"));
     }
 
     #[test]
@@ -283,10 +283,10 @@ mod tests {
         let vt: i32 = 20;
         let limit: i32 = 1;
 
-        let query = read(&qname, &vt, &limit);
+        let query = read(&qname, &vt, &limit).unwrap();
 
-        assert!(query.unwrap().contains(&qname));
-        assert!(query.unwrap().contains(&vt.to_string()));
+        assert!(query.contains(&qname));
+        assert!(query.contains(&vt.to_string()));
     }
 
     #[test]
@@ -294,10 +294,10 @@ mod tests {
         let qname = "myqueue";
         let msg_id: i64 = 42;
 
-        let query = delete(&qname, &msg_id);
+        let query = delete(&qname, &msg_id).unwrap();
 
-        assert!(query.unwrap().contains(&qname));
-        assert!(query.unwrap().contains(&msg_id.to_string()));
+        assert!(query.contains(&qname));
+        assert!(query.contains(&msg_id.to_string()));
     }
 
     #[test]
@@ -308,11 +308,11 @@ mod tests {
         msg_ids.push(43);
         msg_ids.push(44);
 
-        let query = delete_batch(&qname, &msg_ids);
+        let query = delete_batch(&qname, &msg_ids).unwrap();
 
-        assert!(query.unwrap().contains(&qname));
+        assert!(query.contains(&qname));
         for id in msg_ids.iter() {
-            assert!(query.unwrap().contains(&id.to_string()));
+            assert!(query.contains(&id.to_string()));
         }
     }
 

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -1,34 +1,32 @@
 //! Query constructors
 
-use lazy_static::lazy_static;
-use regex::Regex;
-
+use crate::errors::PgmqError;
 pub const TABLE_PREFIX: &str = r#"pgmq"#;
 
-pub fn init_queue(name: &str) -> Vec<String> {
-    check_input(name);
-    vec![
+pub fn init_queue(name: &str) -> Result<Vec<String>, PgmqError> {
+    check_input(name)?;
+    Ok(vec![
         create_meta(),
-        create_queue(name),
-        create_index(name),
-        create_archive(name),
-        insert_meta(name),
-    ]
+        create_queue(name)?,
+        create_index(name)?,
+        create_archive(name)?,
+        insert_meta(name)?,
+    ])
 }
 
-pub fn destory_queue(name: &str) -> Vec<String> {
-    check_input(name);
-    vec![
-        drop_queue(name),
-        delete_queue_index(name),
-        drop_queue_archive(name),
-        delete_queue_metadata(name),
-    ]
+pub fn destory_queue(name: &str) -> Result<Vec<String>, PgmqError> {
+    check_input(name)?;
+    Ok(vec![
+        drop_queue(name)?,
+        delete_queue_index(name)?,
+        drop_queue_archive(name)?,
+        delete_queue_metadata(name)?,
+    ])
 }
 
-pub fn create_queue(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn create_queue(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         CREATE TABLE IF NOT EXISTS {TABLE_PREFIX}_{name} (
             msg_id BIGSERIAL,
@@ -38,12 +36,12 @@ pub fn create_queue(name: &str) -> String {
             message JSON
         );
         "
-    )
+    ))
 }
 
-pub fn create_archive(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn create_archive(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         CREATE TABLE IF NOT EXISTS {TABLE_PREFIX}_{name}_archive (
             msg_id BIGSERIAL,
@@ -54,7 +52,7 @@ pub fn create_archive(name: &str) -> String {
             message JSON
         );
         "
-    )
+    ))
 }
 
 pub fn create_meta() -> String {
@@ -68,27 +66,27 @@ pub fn create_meta() -> String {
     )
 }
 
-pub fn drop_queue(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn drop_queue(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         DROP TABLE IF EXISTS {TABLE_PREFIX}_{name};
         "
-    )
+    ))
 }
 
-pub fn delete_queue_index(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn delete_queue_index(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         DROP INDEX IF EXISTS {TABLE_PREFIX}_{name}.vt_idx_{name};
         "
-    )
+    ))
 }
 
-pub fn delete_queue_metadata(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn delete_queue_metadata(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         DO $$
         BEGIN
@@ -103,43 +101,43 @@ pub fn delete_queue_metadata(name: &str) -> String {
            END IF;
         END $$;
         "
-    )
+    ))
 }
 
-pub fn drop_queue_archive(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn drop_queue_archive(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         DROP TABLE IF EXISTS {TABLE_PREFIX}_{name}_archive;
         "
-    )
+    ))
 }
 
-pub fn insert_meta(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn insert_meta(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         INSERT INTO {TABLE_PREFIX}_meta (queue_name)
         VALUES ('{name}')
         ON CONFLICT
         DO NOTHING;
         "
-    )
+    ))
 }
 
-pub fn create_index(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn create_index(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         CREATE INDEX IF NOT EXISTS vt_idx_{name} ON {TABLE_PREFIX}_{name} (vt ASC);
         "
-    )
+    ))
 }
 
-pub fn enqueue(name: &str, messages: &[serde_json::Value]) -> String {
+pub fn enqueue(name: &str, messages: &[serde_json::Value]) -> Result<String, PgmqError> {
     // TOOO: vt should be now() + delay
     // construct string of comma separated messages
-    check_input(name);
+    check_input(name)?;
     let mut values: String = "".to_owned();
     for message in messages.iter() {
         let full_msg = format!("(now() at time zone 'utc', '{message}'::json),");
@@ -147,18 +145,18 @@ pub fn enqueue(name: &str, messages: &[serde_json::Value]) -> String {
     }
     // drop trailing comma from constructed string
     values.pop();
-    format!(
+    Ok(format!(
         "
         INSERT INTO {TABLE_PREFIX}_{name} (vt, message)
         VALUES {values}
         RETURNING msg_id;
         "
-    )
+    ))
 }
 
-pub fn read(name: &str, vt: &i32, limit: &i32) -> String {
-    check_input(name);
-    format!(
+pub fn read(name: &str, vt: &i32, limit: &i32) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
     WITH cte AS
         (
@@ -176,22 +174,22 @@ pub fn read(name: &str, vt: &i32, limit: &i32) -> String {
     WHERE msg_id in (select msg_id from cte)
     RETURNING *;
     "
-    )
+    ))
 }
 
-pub fn delete(name: &str, msg_id: &i64) -> String {
-    check_input(name);
-    format!(
+pub fn delete(name: &str, msg_id: &i64) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         DELETE FROM {TABLE_PREFIX}_{name}
         WHERE msg_id = {msg_id};
         "
-    )
+    ))
 }
 
-pub fn delete_batch(name: &str, msg_ids: &[i64]) -> String {
+pub fn delete_batch(name: &str, msg_ids: &[i64]) -> Result<String, PgmqError> {
     // construct string of comma separated msg_id
-    check_input(name);
+    check_input(name)?;
     let mut msg_id_list: String = "".to_owned();
     for msg_id in msg_ids.iter() {
         let id_str = format!("{msg_id},");
@@ -199,17 +197,17 @@ pub fn delete_batch(name: &str, msg_ids: &[i64]) -> String {
     }
     // drop trailing comma from constructed string
     msg_id_list.pop();
-    format!(
+    Ok(format!(
         "
         DELETE FROM {TABLE_PREFIX}_{name}
         WHERE msg_id in ({msg_id_list});
         "
-    )
+    ))
 }
 
-pub fn archive(name: &str, msg_id: &i64) -> String {
-    check_input(name);
-    format!(
+pub fn archive(name: &str, msg_id: &i64) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         WITH archived AS (
             DELETE FROM {TABLE_PREFIX}_{name}
@@ -220,12 +218,12 @@ pub fn archive(name: &str, msg_id: &i64) -> String {
         SELECT msg_id, vt, read_ct, enqueued_at, message 
         FROM archived;
         "
-    )
+    ))
 }
 
-pub fn pop(name: &str) -> String {
-    check_input(name);
-    format!(
+pub fn pop(name: &str) -> Result<String, PgmqError> {
+    check_input(name)?;
+    Ok(format!(
         "
         WITH cte AS
             (
@@ -240,16 +238,20 @@ pub fn pop(name: &str) -> String {
         WHERE msg_id = (select msg_id from cte)
         RETURNING *;
         "
-    )
+    ))
 }
 
 /// panics if input is invalid. otherwise does nothing.
-pub fn check_input(input: &str) {
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r#"^[a-zA-Z0-9_]+$"#).unwrap();
-    }
-    if !RE.is_match(input) {
-        panic!("Invalid queue name: {input}")
+pub fn check_input(input: &str) -> Result<(), PgmqError> {
+    let valid = input
+        .as_bytes()
+        .iter()
+        .all(|&c| c.is_ascii_alphanumeric() || c == b'_');
+    match valid {
+        true => Ok(()),
+        false => Err(PgmqError::InvalidQueueName {
+            name: input.to_owned(),
+        }),
     }
 }
 
@@ -260,7 +262,7 @@ mod tests {
     #[test]
     fn test_create() {
         let query = create_queue("yolo");
-        assert!(query.contains("pgmq_yolo"));
+        assert!(query.unwrap().contains("pgmq_yolo"));
     }
 
     #[test]
@@ -271,8 +273,8 @@ mod tests {
         });
         msgs.push(msg);
         let query = enqueue("yolo", &msgs);
-        assert!(query.contains("pgmq_yolo"));
-        assert!(query.contains("{\"foo\":\"bar\"}"));
+        assert!(query.unwrap().contains("pgmq_yolo"));
+        assert!(query.unwrap().contains("{\"foo\":\"bar\"}"));
     }
 
     #[test]
@@ -283,8 +285,8 @@ mod tests {
 
         let query = read(&qname, &vt, &limit);
 
-        assert!(query.contains(&qname));
-        assert!(query.contains(&vt.to_string()));
+        assert!(query.unwrap().contains(&qname));
+        assert!(query.unwrap().contains(&vt.to_string()));
     }
 
     #[test]
@@ -294,8 +296,8 @@ mod tests {
 
         let query = delete(&qname, &msg_id);
 
-        assert!(query.contains(&qname));
-        assert!(query.contains(&msg_id.to_string()));
+        assert!(query.unwrap().contains(&qname));
+        assert!(query.unwrap().contains(&msg_id.to_string()));
     }
 
     #[test]
@@ -308,27 +310,19 @@ mod tests {
 
         let query = delete_batch(&qname, &msg_ids);
 
-        assert!(query.contains(&qname));
+        assert!(query.unwrap().contains(&qname));
         for id in msg_ids.iter() {
-            assert!(query.contains(&id.to_string()));
+            assert!(query.unwrap().contains(&id.to_string()));
         }
     }
 
     #[test]
     #[should_panic]
-    fn test_check_input_0() {
-        check_input("bad;queue_name");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_check_input_1() {
-        check_input("bad name");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_check_input_2() {
-        check_input("bad--name");
+    fn test_check_input() {
+        let invalids = vec!["bad;queue_name", "bad name", "bad--name"];
+        for i in invalids.iter() {
+            let is_valid = check_input(i);
+            assert!(!is_valid.is_err())
+        }
     }
 }


### PR DESCRIPTION
- Use `Result` instead of `panic!` when there are invalid input values.
- check byte values instead of regex, which is a bit faster. 33ns vs 13ns on a decent size string. Added the benchmark to `./benches`, and snipped below.

@yrashk 


```
check bytes             time:   [13.480 ns 13.534 ns 13.592 ns]
                        change: [+1.5645% +2.0646% +2.5431%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

check regex             time:   [33.798 ns 33.899 ns 34.010 ns]
                        change: [-0.0699% +0.3138% +0.7198%] (p = 0.11 > 0.05)
                        No change in performance detected.
```