### PR TITLE
Add missing metadata to `pgui-api` crate

### DIFF
--- a/pgUI/api/Cargo.toml
+++ b/pgUI/api/Cargo.toml
@@ -2,6 +2,12 @@
 name = "pgui-api"
 version = "0.1.0"
 edition = "2021"
+authors = ["CoreDB.io"]
+description = "A backend API for pgUI."
+homepage = "https://www.coredb.io"
+keywords = ["api", "postgres"]
+license = "Apache-2.0"
+repository = "https://github.com/CoreDB-io/coredb/tree/main/pgUI/api"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Fixes the following failure: https://github.com/CoreDB-io/coredb/actions/runs/4294135008/jobs/7482747784