### PR TITLE
pgmq: use JSONB instead of JSON

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -33,7 +33,7 @@ pub fn create_queue(name: &str) -> Result<String, PgmqError> {
             read_ct INT DEFAULT 0,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc'),
             vt TIMESTAMP WITH TIME ZONE,
-            message JSON
+            message JSONB
         );
         "
     ))
@@ -49,7 +49,7 @@ pub fn create_archive(name: &str) -> Result<String, PgmqError> {
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc'),
             deleted_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc'),
             vt TIMESTAMP WITH TIME ZONE,
-            message JSON
+            message JSONB
         );
         "
     ))


### PR DESCRIPTION
JSONB is generally preferred for its efficiency as opposed to plain-text storage.

Closes #143