### PR TITLE
jsonb for partitioned tables

### DIFF
--- a/extensions/pgmq/Cargo.lock
+++ b/extensions/pgmq/Cargo.lock
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 dependencies = [
- "pgmq 0.7.5",
+ "pgmq 0.8.1",
  "pgx",
  "pgx-tests",
  "serde",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8858bb794834502613982709c53219967cfd836f204c65cfb87accbf4901638"
+checksum = "fd6975ba33a7c9af421ea36f98b0fbc480327f6709f786c76d566e62f86ec110"
 dependencies = [
  "chrono",
  "log",

--- a/extensions/pgmq/Cargo.toml
+++ b/extensions/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"

--- a/extensions/pgmq/Cargo.toml
+++ b/extensions/pgmq/Cargo.toml
@@ -25,7 +25,7 @@ pg_test = []
 [dependencies]
 pgx = "0.7.1"
 serde = "1.0.152"
-pgmq_crate = { package = "pgmq", version = "0.7.5" }
+pgmq_crate = { package = "pgmq", version = "0.8.1" }
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 

--- a/extensions/pgmq/src/partition.rs
+++ b/extensions/pgmq/src/partition.rs
@@ -29,7 +29,7 @@ pub fn create_partitioned_queue(queue: &str) -> Result<String, PgmqError> {
             read_ct INT DEFAULT 0,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc'),
             vt TIMESTAMP WITH TIME ZONE,
-            message JSON
+            message JSONB
         ) PARTITION BY RANGE (msg_id);;
         "
     ))

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb"
-version = "15.1.0-coredb.8"
+version = "15.1.0-coredb.9"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"


### PR DESCRIPTION
https://github.com/CoreDB-io/coredb/pull/144 changed the non-partitioned queues to jsonb. This does the same for partitioned queues.