### PR TITLE
Operator extensions

### DIFF
--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -23,7 +23,7 @@ use kube::{
 };
 
 use crate::{
-    extensions::create_extensions, postgres_exporter_role::create_postgres_exporter_role,
+    extensions::manage_extensions, postgres_exporter_role::create_postgres_exporter_role,
     secret::reconcile_secret,
 };
 use k8s_openapi::{
@@ -193,7 +193,7 @@ impl CoreDB {
             return Ok(Action::requeue(Duration::from_secs(1)));
         }
 
-        create_extensions(self, ctx.clone()).await.expect(&format!(
+        manage_extensions(self, ctx.clone()).await.expect(&format!(
             "Error creating extensions on CoreDB {}",
             self.metadata.name.clone().unwrap()
         ));

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -66,7 +66,7 @@ pub struct CoreDBSpec {
     #[serde(default = "defaults::default_uid")]
     pub uid: i32,
     #[serde(default = "defaults::default_extensions")]
-    pub enabledExtensions: Vec<String>,
+    pub extensions: Vec<Extension>,
 }
 
 /// The status object of `CoreDB`
@@ -84,6 +84,25 @@ pub struct Context {
     pub diagnostics: Arc<RwLock<Diagnostics>>,
     /// Prometheus metrics
     pub metrics: Metrics,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
+pub struct Extension {
+    pub name: String,
+    pub version: String,
+    pub enabled: bool,
+    pub schema: String,
+}
+
+impl Default for Extension {
+    fn default() -> Self {
+        Extension {
+            name: "pg_stat_statements".to_owned(),
+            version: "1.9".to_owned(),
+            enabled: true,
+            schema: "postgres".to_owned(),
+        }
+    }
 }
 
 #[instrument(skip(ctx, cdb), fields(trace_id))]

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -1,6 +1,8 @@
 use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::resource::Quantity};
 use std::collections::BTreeMap;
 
+use crate::Extension;
+
 pub fn default_replicas() -> i32 {
     1
 }
@@ -44,6 +46,6 @@ pub fn default_postgres_exporter_image() -> String {
     "quay.io/prometheuscommunity/postgres-exporter:v0.11.1".to_owned()
 }
 
-pub fn default_extensions() -> Vec<String> {
-    vec![]
+pub fn default_extensions() -> Vec<Extension> {
+    vec![Extension::default()]
 }

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -3,9 +3,9 @@ use regex::Regex;
 use std::sync::Arc;
 use tracing::debug;
 
-pub async fn create_extensions(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
+pub async fn manage_extensions(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
     let client = ctx.client.clone();
-    let extensions = &cdb.spec.enabledExtensions;
+    let extensions = &cdb.spec.extensions;
     let re = Regex::new(r"[a-zA-Z][0-9a-zA-Z_-]*$").unwrap();
 
     // TODO(ianstanton) Some extensions will fail to create. We need to handle and surface any errors.
@@ -13,20 +13,38 @@ pub async fn create_extensions(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Er
 
     // iterate through list of extensions and run CREATE EXTENSION <extension-name> for each
     for ext in extensions {
-        if !re.is_match(ext) {
-            debug!("Extension {} is not formatted properly. Skipping creation.", ext)
+        let ext_name = ext.name.as_str();
+        if !re.is_match(ext_name) {
+            debug!(
+                "Extension {} is not formatted properly. Skipping creation.",
+                ext_name
+            )
         } else {
-            debug!("Creating extension: {}", ext);
-            // this will no-op if we've already created the extension
-            let result = cdb
-                .psql(
-                    format!("CREATE EXTENSION {};", ext),
-                    "postgres".to_owned(),
-                    client.clone(),
-                )
-                .await
-                .unwrap();
-            debug!("Result: {}", result.stdout.clone().unwrap());
+            if ext.enabled {
+                debug!("Creating extension: {}", ext_name);
+                // this will no-op if we've already created the extension
+                let result = cdb
+                    .psql(
+                        format!("CREATE EXTENSION {ext_name} IF NOT EXISTS;"),
+                        "postgres".to_owned(),
+                        client.clone(),
+                    )
+                    .await
+                    .unwrap();
+                debug!("Result: {}", result.stdout.clone().unwrap());
+            } else {
+                debug!("Dropping extension: {}", ext_name);
+                // this will no-op if we've already created the extension
+                let result = cdb
+                    .psql(
+                        format!("DROP EXTENSION IF EXISTS {ext_name};"),
+                        "postgres".to_owned(),
+                        client.clone(),
+                    )
+                    .await
+                    .unwrap();
+                debug!("Result: {}", result.stdout.clone().unwrap());
+            }
         }
     }
     Ok(())

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -11,7 +11,8 @@ pub use metrics::Metrics;
 
 pub mod defaults;
 mod extensions;
-#[cfg(test)] pub mod fixtures;
+#[cfg(test)]
+pub mod fixtures;
 mod postgres_exporter_role;
 mod psql;
 mod secret;

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -118,7 +118,7 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
-                "enabledExtensions": ["postgis"]
+                "extensions": [{"name": "postgis", "enabled": true, "version": "1.1.1", "schema": "public"}]
             }
         });
         let params = PatchParams::apply("coredb-integration-test");
@@ -298,7 +298,7 @@ mod test {
             },
             "spec": {
                 "replicas": 1,
-                "enabledExtensions": ["postgis"]
+                "extensions": [{"name": "postgis", "enabled": true, "version": "1.1.1", "schema": "public"}],
             }
         });
         let params = PatchParams::apply("coredb-integration-test");

--- a/coredb-operator/yaml/crd.yaml
+++ b/coredb-operator/yaml/crd.yaml
@@ -25,10 +25,28 @@ spec:
 
               This provides a hook for generating the CRD yaml (in crdgen.rs)
             properties:
-              enabledExtensions:
-                default: []
+              extensions:
+                default:
+                - name: pg_stat_statements
+                  version: '1.9'
+                  enabled: true
+                  schema: postgres
                 items:
-                  type: string
+                  properties:
+                    enabled:
+                      type: boolean
+                    name:
+                      type: string
+                    schema:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - enabled
+                  - name
+                  - schema
+                  - version
+                  type: object
                 type: array
               image:
                 default: quay.io/coredb/postgres:c03124e

--- a/coredb-operator/yaml/sample-coredb.yaml
+++ b/coredb-operator/yaml/sample-coredb.yaml
@@ -4,5 +4,8 @@ metadata:
   name: sample-coredb
 spec:
   replicas: 1
-  enabledExtensions:
-    - postgis
+  extensions:
+    - name: "pg_stat_statements"
+      enabled: true
+      version: "1.9"
+      schema: "postgres"


### PR DESCRIPTION
Updates CoreDB operator to handle the extension specification object. Inspects the `enabled` attribute, and runs create/drop as necessary.

Add the `if exists` and `if not exists` to the create/drop statements.