### PR TITLE
Only push images on commit to main branch

### DIFF
--- a/.github/actions/build-and-push-to-quay/action.yml
+++ b/.github/actions/build-and-push-to-quay/action.yml
@@ -107,6 +107,7 @@ runs:
           docker tag ${{ inputs.image_name }} ${{ inputs.image_name }}:$tag
         done
     - name: Push To quay.io
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: redhat-actions/push-to-registry@v2
       with:
         registry: ${{ inputs.registry }}

--- a/pgUI/api/Dockerfile
+++ b/pgUI/api/Dockerfile
@@ -8,4 +8,4 @@ RUN cargo install --path .
 # second stage.
 FROM rust:1.66.1-slim-buster
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
-ENV RUST_LOG=info
+ENV RUST_LOG=debug

--- a/pgUI/api/Dockerfile
+++ b/pgUI/api/Dockerfile
@@ -8,4 +8,4 @@ RUN cargo install --path .
 # second stage.
 FROM rust:1.66.1-slim-buster
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
-ENV RUST_LOG=debug
+ENV RUST_LOG=info


### PR DESCRIPTION
We've been pushing images to quay.io on each commit in open PRs. It's important to build images on these commits, but we don't need to push until we merge to `main`.

This change ensures we only push images when this action runs on `main`. To test, we made a change to the pgui-api Dockerfile (reverted now).:
![image](https://user-images.githubusercontent.com/8935584/223242033-c15ff484-b7e3-4af1-8ab8-140f11b44261.png)
