### PR TITLE
Clean up CI failures after `trunk` migration

### DIFF
--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.0.1-alpha.3"
+version = "0.0.1-alpha.4"
 edition = "2021"
 authors = ["Steven Miller"]
 description = "A package manager for PostgreSQL extensions"

--- a/trunk/cli/tests/test_extension/Cargo.toml
+++ b/trunk/cli/tests/test_extension/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_extension"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/trunk/registry/Cargo.toml
+++ b/trunk/registry/Cargo.toml
@@ -17,5 +17,5 @@ serde = { version = "1.0.154", features = ["derive"] }
 futures = "0.3.26"
 serde_json = "1.0.94"
 chrono = "0.4.23"
-registry-s3 = { path = "registry-s3" }
+registry-s3 = { version = "0.2.0", path = "registry-s3" }
 dotenv = "0.15.0"


### PR DESCRIPTION
There were a handful of CI failures after moving the `trunk` repositories. This is an attempt to resolve those failures.