### PR TITLE
Add Nick to coredb-operator codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*       @ryw @ianstanton @ChuckHend @sjmiller609
+*       @ChuckHend @ianstanton @ryw @sjmiller609
 /coredb-operator/ @ChuckHend @ianstanton @nhudson @sjmiller609

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @ryw @ianstanton @ChuckHend @sjmiller609
+/coredb-operator/ @ChuckHend @ianstanton @nhudson @sjmiller609


### PR DESCRIPTION
Not sure if we need to include the names covered under `*`. Also alphabetize current names under `*`.