### PR TITLE
Move CoreDB Type Definition into `apis` dir

### DIFF
--- a/coredb-operator/src/apis/coredb_types.rs
+++ b/coredb-operator/src/apis/coredb_types.rs
@@ -1,0 +1,48 @@
+use crate::extensions::Extension;
+use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::resource::Quantity};
+
+use crate::defaults;
+use kube::CustomResource;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
+///
+/// This provides a hook for generating the CRD yaml (in crdgen.rs)
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[cfg_attr(test, derive(Default))]
+#[kube(kind = "CoreDB", group = "coredb.io", version = "v1alpha1", namespaced)]
+#[kube(status = "CoreDBStatus", shortname = "cdb")]
+#[allow(non_snake_case)]
+pub struct CoreDBSpec {
+    #[serde(default = "defaults::default_replicas")]
+    pub replicas: i32,
+    #[serde(default = "defaults::default_resources")]
+    pub resources: ResourceRequirements,
+    #[serde(default = "defaults::default_storage")]
+    pub storage: Quantity,
+    #[serde(default = "defaults::default_postgres_exporter_enabled")]
+    pub postgresExporterEnabled: bool,
+    #[serde(default = "defaults::default_image")]
+    pub image: String,
+    #[serde(default = "defaults::default_postgres_exporter_image")]
+    pub postgresExporterImage: String,
+    #[serde(default = "defaults::default_port")]
+    pub port: i32,
+    #[serde(default = "defaults::default_uid")]
+    pub uid: i32,
+    #[serde(default = "defaults::default_extensions")]
+    pub extensions: Vec<Extension>,
+    #[serde(default = "defaults::default_stop")]
+    pub stop: bool,
+}
+
+/// The status object of `CoreDB`
+#[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
+pub struct CoreDBStatus {
+    pub running: bool,
+    pub extensions: Option<Vec<Extension>>,
+    #[serde(default = "defaults::default_storage")]
+    pub storage: Quantity,
+}

--- a/coredb-operator/src/apis/mod.rs
+++ b/coredb-operator/src/apis/mod.rs
@@ -1,0 +1,1 @@
+pub mod coredb_types;

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -6,7 +6,6 @@ use futures::{
 };
 
 use crate::{
-    defaults,
     psql::{PsqlCommand, PsqlOutput},
     service::reconcile_svc,
     statefulset::{reconcile_sts, stateful_set_from_cdb},
@@ -19,66 +18,24 @@ use kube::{
         events::{Event, EventType, Recorder, Reporter},
         finalizer::{finalizer, Event as Finalizer},
     },
-    CustomResource, Resource,
+    Resource,
 };
 
 use crate::{
-    extensions::reconcile_extensions, postgres_exporter_role::create_postgres_exporter_role,
+    apis::coredb_types::{CoreDB, CoreDBStatus},
+    extensions::{reconcile_extensions, Extension},
+    postgres_exporter_role::create_postgres_exporter_role,
     secret::reconcile_secret,
 };
-use k8s_openapi::{
-    api::core::v1::{Namespace, Pod, ResourceRequirements},
-    apimachinery::pkg::api::resource::Quantity,
-};
+use k8s_openapi::api::core::v1::{Namespace, Pod};
 use kube::runtime::wait::Condition;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::{sync::RwLock, time::Duration};
 use tracing::*;
 
 pub static COREDB_FINALIZER: &str = "coredbs.coredb.io";
-
-/// Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
-///
-/// This provides a hook for generating the CRD yaml (in crdgen.rs)
-#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
-#[cfg_attr(test, derive(Default))]
-#[kube(kind = "CoreDB", group = "coredb.io", version = "v1alpha1", namespaced)]
-#[kube(status = "CoreDBStatus", shortname = "cdb")]
-#[allow(non_snake_case)]
-pub struct CoreDBSpec {
-    #[serde(default = "defaults::default_replicas")]
-    pub replicas: i32,
-    #[serde(default = "defaults::default_resources")]
-    pub resources: ResourceRequirements,
-    #[serde(default = "defaults::default_storage")]
-    pub storage: Quantity,
-    #[serde(default = "defaults::default_postgres_exporter_enabled")]
-    pub postgresExporterEnabled: bool,
-    #[serde(default = "defaults::default_image")]
-    pub image: String,
-    #[serde(default = "defaults::default_postgres_exporter_image")]
-    pub postgresExporterImage: String,
-    #[serde(default = "defaults::default_port")]
-    pub port: i32,
-    #[serde(default = "defaults::default_uid")]
-    pub uid: i32,
-    #[serde(default = "defaults::default_extensions")]
-    pub extensions: Vec<Extension>,
-    #[serde(default = "defaults::default_stop")]
-    pub stop: bool,
-}
-
-/// The status object of `CoreDB`
-#[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
-pub struct CoreDBStatus {
-    pub running: bool,
-    pub extensions: Option<Vec<Extension>>,
-    #[serde(default = "defaults::default_storage")]
-    pub storage: Quantity,
-}
 
 // Context for our reconciler
 #[derive(Clone)]
@@ -89,47 +46,6 @@ pub struct Context {
     pub diagnostics: Arc<RwLock<Diagnostics>>,
     /// Prometheus metrics
     pub metrics: Metrics,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Serialize, PartialEq)]
-pub struct Extension {
-    pub name: String,
-    #[serde(default = "defaults::default_description")]
-    pub description: String,
-    pub locations: Vec<ExtensionInstallLocation>,
-}
-
-impl Default for Extension {
-    fn default() -> Self {
-        Extension {
-            name: "pg_stat_statements".to_owned(),
-            description: " track planning and execution statistics of all SQL statements executed".to_owned(),
-            locations: vec![ExtensionInstallLocation::default()],
-        }
-    }
-}
-
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Serialize, PartialEq)]
-pub struct ExtensionInstallLocation {
-    pub enabled: bool,
-    // no database or schema when disabled
-    #[serde(default = "defaults::default_database")]
-    pub database: String,
-    #[serde(default = "defaults::default_schema")]
-    pub schema: String,
-    pub version: Option<String>,
-}
-
-impl Default for ExtensionInstallLocation {
-    fn default() -> Self {
-        ExtensionInstallLocation {
-            schema: "public".to_owned(),
-            database: "postgres".to_owned(),
-            enabled: true,
-            version: Some("1.9".to_owned()),
-        }
-    }
 }
 
 #[instrument(skip(ctx, cdb), fields(trace_id))]

--- a/coredb-operator/src/crdgen.rs
+++ b/coredb-operator/src/crdgen.rs
@@ -1,4 +1,5 @@
 use kube::CustomResourceExt;
+use controller::apis::coredb_types::CoreDB;
 fn main() {
-    print!("{}", serde_yaml::to_string(&controller::CoreDB::crd()).unwrap())
+    print!("{}", serde_yaml::to_string(&CoreDB::crd()).unwrap())
 }

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -1,7 +1,7 @@
 use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::resource::Quantity};
 use std::collections::BTreeMap;
 
-use crate::Extension;
+use crate::extensions::Extension;
 
 pub fn default_replicas() -> i32 {
     1

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -1,6 +1,7 @@
 /// Expose all controller components used by main
 pub mod controller;
 pub use crate::controller::*;
+pub mod apis;
 
 /// Log and trace integrations
 pub mod telemetry;
@@ -8,7 +9,6 @@ pub mod telemetry;
 /// Metrics
 mod metrics;
 pub use metrics::Metrics;
-
 pub mod defaults;
 mod extensions;
 #[cfg(test)] pub mod fixtures;

--- a/coredb-operator/src/metrics.rs
+++ b/coredb-operator/src/metrics.rs
@@ -1,4 +1,4 @@
-use crate::{CoreDB, Error};
+use crate::{apis::coredb_types::CoreDB, Error};
 use kube::ResourceExt;
 use prometheus::{histogram_opts, opts, HistogramVec, IntCounter, IntCounterVec, Registry};
 use tokio::time::Instant;

--- a/coredb-operator/src/postgres_exporter_role.rs
+++ b/coredb-operator/src/postgres_exporter_role.rs
@@ -1,4 +1,4 @@
-use crate::{Context, CoreDB, Error};
+use crate::{apis::coredb_types::CoreDB, Context, Error};
 use std::sync::Arc;
 use tracing::debug;
 

--- a/coredb-operator/src/secret.rs
+++ b/coredb-operator/src/secret.rs
@@ -1,4 +1,4 @@
-use crate::{Context, CoreDB, Error};
+use crate::{apis::coredb_types::CoreDB, Context, Error};
 use k8s_openapi::{api::core::v1::Secret, apimachinery::pkg::apis::meta::v1::ObjectMeta, ByteString};
 use kube::{
     api::{ListParams, Patch, PatchParams},

--- a/coredb-operator/src/service.rs
+++ b/coredb-operator/src/service.rs
@@ -1,4 +1,4 @@
-use crate::{Context, CoreDB, Error};
+use crate::{apis::coredb_types::CoreDB, Context, Error};
 use k8s_openapi::{
     api::core::v1::{Service, ServicePort, ServiceSpec},
     apimachinery::pkg::{apis::meta::v1::ObjectMeta, util::intstr::IntOrString},

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -1,4 +1,4 @@
-use crate::{Context, CoreDB, Error, Result};
+use crate::{apis::coredb_types::CoreDB, Context, Error, Result};
 use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetSpec},
@@ -310,7 +310,10 @@ async fn update_pvc(client: Client, sts: &StatefulSet, cdb: &CoreDB) {
 #[cfg(test)]
 mod tests {
     use super::{stateful_set_from_cdb, StatefulSet};
-    use crate::{CoreDB, CoreDBSpec};
+    use crate::{
+        apis::coredb_types::{CoreDB, CoreDBSpec},
+        CoreDB, CoreDBSpec,
+    };
     use kube::Resource;
 
     #[test]

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -450,7 +450,6 @@ mod test {
         });
     }
 
-
     #[tokio::test]
     #[ignore]
     async fn test_stop_instance() {
@@ -635,7 +634,6 @@ mod test {
         println!("{}", result.stdout.clone().unwrap());
         assert!(result.stdout.clone().unwrap().contains("stop_test"));
     }
-
 
     async fn kube_client() -> Client {
         // Get the name of the currently selected namespace


### PR DESCRIPTION
- Move the CoreDB type definition to a `coredb_types.rs` file in `/src/apis/`
- This gives us similar structure seen in most operator projects. It doesn't belong in the `controller.rs` file (that was pulled in from an example). Examples:
  - https://github.com/cloudnative-pg/cloudnative-pg/blob/main/api/v1/cluster_types.go
  - https://github.com/CrunchyData/postgres-operator/blob/master/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
- Inspired by kubebuilder structure for golang based operators:
![image](https://user-images.githubusercontent.com/8935584/227497271-00756d77-54a3-4dab-9ba4-e2c6de272685.png)



- Move extension related structs to `extensions.rs`.