### PR TITLE
Rusty/tinyoptimization

### DIFF
--- a/crates/pgmq/Cargo.toml
+++ b/crates/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -332,7 +332,7 @@ impl PGMQueue {
         message: &T,
     ) -> Result<i64, errors::PgmqError> {
         let msg = serde_json::json!(&message);
-        let msgs:[serde_json::Value;1] = [msg];
+        let msgs: [serde_json::Value; 1] = [msg];
         let row: PgRow = sqlx::query(&query::enqueue(queue_name, &msgs)?)
             .fetch_one(&self.connection)
             .await?;

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -331,9 +331,8 @@ impl PGMQueue {
         queue_name: &str,
         message: &T,
     ) -> Result<i64, errors::PgmqError> {
-        let mut msgs: Vec<serde_json::Value> = Vec::new();
         let msg = serde_json::json!(&message);
-        msgs.push(msg);
+        let msgs:[serde_json::Value;1] = [msg];
         let row: PgRow = sqlx::query(&query::enqueue(queue_name, &msgs)?)
             .fetch_one(&self.connection)
             .await?;


### PR DESCRIPTION
- Update send function to use an array for storing the msg inside of an iterable before it is sent to the enqueue function. By using an array we can take advantage of the tiny memory win because the array is put onto the stack as the size of the array is known at the time of its creation, whereas the vector is placed on the heap due to its dynamic nature. We also get to remove one line of code :)!
- Bump patch version.