### PR TITLE
[COR-526] Improve JSON response for `/extensions/all`

### DIFF
--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -2,7 +2,6 @@ use crate::config::Config;
 use crate::connect;
 use crate::errors::ExtensionRegistryError;
 use actix_web::{get, web, HttpResponse, Responder};
-use sqlx::Row;
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -11,7 +10,7 @@ pub struct Extension {
     description: String,
     homepage: String,
     documentation: String,
-    repository: String
+    repository: String,
 }
 
 #[get("/")]
@@ -38,7 +37,7 @@ pub async fn get_all_extensions(
             description: row.description.as_ref().unwrap().to_owned(),
             homepage: row.homepage.as_ref().unwrap().to_owned(),
             documentation: row.documentation.as_ref().unwrap().to_owned(),
-            repository: row.repository.as_ref().unwrap().to_owned()
+            repository: row.repository.as_ref().unwrap().to_owned(),
         };
         extensions.push(ext);
     }

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -2,7 +2,6 @@ use crate::config::Config;
 use crate::connect;
 use crate::errors::ExtensionRegistryError;
 use actix_web::{get, web, HttpResponse, Responder};
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 #[get("/")]
@@ -36,5 +35,5 @@ pub async fn get_all_extensions(
     }
     // Return results in response
     let json = serde_json::to_string_pretty(&extensions)?;
-    Ok(HttpResponse::Ok().body(format!("{}", json)))
+    Ok(HttpResponse::Ok().body(json))
 }

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -25,13 +25,13 @@ pub async fn get_all_extensions(
         .await?;
     for row in rows.iter() {
         let data = json!(
-            {
-              "name": row.name.to_owned(),
-              "description": row.description.to_owned(),
-              "homepage": row.homepage.to_owned(),
-              "documentation": row.documentation.to_owned(),
-              "repository": row.repository.to_owned()
-            });
+        {
+          "name": row.name.to_owned(),
+          "description": row.description.to_owned(),
+          "homepage": row.homepage.to_owned(),
+          "documentation": row.documentation.to_owned(),
+          "repository": row.repository.to_owned()
+        });
         extensions.push(data);
     }
     // Return results in response

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -6,11 +6,11 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct Extension {
-    name: String,
-    description: String,
-    homepage: String,
-    documentation: String,
-    repository: String,
+    name: Option<String>,
+    description: Option<String>,
+    homepage: Option<String>,
+    documentation: Option<String>,
+    repository: Option<String>,
 }
 
 #[get("/")]
@@ -33,11 +33,11 @@ pub async fn get_all_extensions(
         .await?;
     for row in rows.iter() {
         let ext = Extension {
-            name: row.name.as_ref().unwrap().to_owned(),
-            description: row.description.as_ref().unwrap().to_owned(),
-            homepage: row.homepage.as_ref().unwrap().to_owned(),
-            documentation: row.documentation.as_ref().unwrap().to_owned(),
-            repository: row.repository.as_ref().unwrap().to_owned(),
+            name: row.name.to_owned(),
+            description: row.description.to_owned(),
+            homepage: row.homepage.to_owned(),
+            documentation: row.documentation.to_owned(),
+            repository: row.repository.to_owned(),
         };
         extensions.push(ext);
     }

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -2,16 +2,8 @@ use crate::config::Config;
 use crate::connect;
 use crate::errors::ExtensionRegistryError;
 use actix_web::{get, web, HttpResponse, Responder};
-use serde::Serialize;
-
-#[derive(Debug, Serialize)]
-pub struct Extension {
-    name: Option<String>,
-    description: Option<String>,
-    homepage: Option<String>,
-    documentation: Option<String>,
-    repository: Option<String>,
-}
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 #[get("/")]
 pub async fn running() -> impl Responder {
@@ -22,7 +14,7 @@ pub async fn running() -> impl Responder {
 pub async fn get_all_extensions(
     cfg: web::Data<Config>,
 ) -> Result<HttpResponse, ExtensionRegistryError> {
-    let mut extensions: Vec<Extension> = Vec::new();
+    let mut extensions: Vec<Value> = Vec::new();
     // Set database conn
     let conn = connect(&cfg.database_url).await?;
     // Create a transaction on the database, if there are no errors,
@@ -32,16 +24,17 @@ pub async fn get_all_extensions(
         .fetch_all(&mut tx)
         .await?;
     for row in rows.iter() {
-        let ext = Extension {
-            name: row.name.to_owned(),
-            description: row.description.to_owned(),
-            homepage: row.homepage.to_owned(),
-            documentation: row.documentation.to_owned(),
-            repository: row.repository.to_owned(),
-        };
-        extensions.push(ext);
+        let data = json!(
+            {
+              "name": row.name.to_owned(),
+              "description": row.description.to_owned(),
+              "homepage": row.homepage.to_owned(),
+              "documentation": row.documentation.to_owned(),
+              "repository": row.repository.to_owned()
+            });
+        extensions.push(data);
     }
     // Return results in response
-    let json = serde_json::to_string(&extensions);
-    Ok(HttpResponse::Ok().body(format!("{:?}", json)))
+    let json = serde_json::to_string_pretty(&extensions)?;
+    Ok(HttpResponse::Ok().body(format!("{}", json)))
 }


### PR DESCRIPTION
Add more fields to `/extensions/all` JSON response. Example response:
```
[
  {
    "description": "easy message queues with postgres",
    "documentation": null,
    "homepage": "coredb.io",
    "name": "pgmq",
    "repository": null
  }
]
```

TODO:
- Follow-up including
  - updated_at
  - created_at
  - downloads
  - latest version
  - publisher for latest version