### PR TITLE
Remove diesel.toml

### DIFF
--- a/trunk/registry/diesel.toml
+++ b/trunk/registry/diesel.toml
@@ -1,8 +1,0 @@
-# For documentation on how to configure this file,
-# see https://diesel.rs/guides/configuring-diesel-cli
-
-[print_schema]
-file = "src/schema.rs"
-
-[migrations_directory]
-dir = "migrations"


### PR DESCRIPTION
We recently removed `diesel` for migrations in favor of `sqlx`. Remove leftover `diesel.toml` file.