### PR TITLE
Fix missing CA bug in trunk registry

### DIFF
--- a/trunk/registry/Dockerfile
+++ b/trunk/registry/Dockerfile
@@ -9,3 +9,6 @@ RUN cargo install --path .
 # second stage.
 FROM debian
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends ca-certificates
+RUN update-ca-certificates


### PR DESCRIPTION
Resolves `'no CA certificates found'` crashloop in trunk registry backend.

Related to: 
- https://github.com/awslabs/aws-sdk-rust/discussions/434#discussioncomment-2090346