### PR TITLE
handle pvc updates

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           set -xe
           # Install the CRD
+          kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
           cargo run --bin crdgen | kubectl apply -f -
           kubectl get crds
           # Start the operator in the background

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -308,8 +308,76 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              pkglibdirStorage:
+                description: |-
+                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                  The serialization format is:
+
+                  <quantity>        ::= <signedNumber><suffix>
+                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                    a. No precision is lost
+                    b. No fractional digits will be emitted
+                    c. The exponent (or suffix) is as large as possible.
+                  The sign will be omitted unless the number is negative.
+
+                  Examples:
+                    1.5 will be serialized as "1500m"
+                    1.5Gi will be serialized as "1536Mi"
+
+                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                type: string
               running:
                 type: boolean
+              sharedirStorage:
+                description: |-
+                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                  The serialization format is:
+
+                  <quantity>        ::= <signedNumber><suffix>
+                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                    a. No precision is lost
+                    b. No fractional digits will be emitted
+                    c. The exponent (or suffix) is as large as possible.
+                  The sign will be omitted unless the number is negative.
+
+                  Examples:
+                    1.5 will be serialized as "1500m"
+                    1.5Gi will be serialized as "1536Mi"
+
+                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                type: string
               storage:
                 default: 8Gi
                 description: |-
@@ -346,7 +414,9 @@ spec:
                   This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                 type: string
             required:
+            - pkglibdirStorage
             - running
+            - sharedirStorage
             type: object
         required:
         - spec

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -61,7 +61,7 @@ spec:
                 default: quay.io/coredb/postgres:6e3c4a7
                 type: string
               pkglibdirStorage:
-                default: 250Mi
+                default: 1Gi
                 description: |-
                   Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
@@ -195,7 +195,7 @@ spec:
                     type: object
                 type: object
               sharedirStorage:
-                default: 250Mi
+                default: 1Gi
                 description: |-
                   Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
@@ -309,6 +309,7 @@ spec:
                 nullable: true
                 type: array
               pkglibdirStorage:
+                default: 1Gi
                 description: |-
                   Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
@@ -345,6 +346,7 @@ spec:
               running:
                 type: boolean
               sharedirStorage:
+                default: 1Gi
                 description: |-
                   Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
@@ -414,9 +416,7 @@ spec:
                   This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                 type: string
             required:
-            - pkglibdirStorage
             - running
-            - sharedirStorage
             type: object
         required:
         - spec

--- a/coredb-operator/scripts/reset-local-test-cluster.sh
+++ b/coredb-operator/scripts/reset-local-test-cluster.sh
@@ -12,6 +12,9 @@ kind create cluster
 # Label the default namespace as safe to run tests
 kubectl label namespace default safe-to-run-coredb-tests=true
 
+# patch storageclass to allow volume expansion
+kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+
 # Install CoreDB CRDs
 cd $SCRIPT_DIR
 cd ..

--- a/coredb-operator/src/apis/coredb_types.rs
+++ b/coredb-operator/src/apis/coredb_types.rs
@@ -50,6 +50,8 @@ pub struct CoreDBStatus {
     pub extensions: Option<Vec<Extension>>,
     #[serde(default = "defaults::default_storage")]
     pub storage: Quantity,
+    #[serde(default = "defaults::default_sharedir_storage")]
     pub sharedirStorage: Quantity,
+    #[serde(default = "defaults::default_pkglibdir_storage")]
     pub pkglibdirStorage: Quantity,
 }

--- a/coredb-operator/src/apis/coredb_types.rs
+++ b/coredb-operator/src/apis/coredb_types.rs
@@ -44,9 +44,12 @@ pub struct CoreDBSpec {
 
 /// The status object of `CoreDB`
 #[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
+#[allow(non_snake_case)]
 pub struct CoreDBStatus {
     pub running: bool,
     pub extensions: Option<Vec<Extension>>,
     #[serde(default = "defaults::default_storage")]
     pub storage: Quantity,
+    pub sharedirStorage: Quantity,
+    pub pkglibdirStorage: Quantity,
 }

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -145,12 +145,16 @@ impl CoreDB {
                 CoreDBStatus {
                     running: true,
                     storage: self.spec.storage.clone(),
+                    sharedirStorage: self.spec.sharedirStorage.clone(),
+                    pkglibdirStorage: self.spec.pkglibdirStorage.clone(),
                     extensions: Some(extensions),
                 }
             }
             true => CoreDBStatus {
                 running: false,
                 storage: self.spec.storage.clone(),
+                sharedirStorage: self.spec.sharedirStorage.clone(),
+                pkglibdirStorage: self.spec.pkglibdirStorage.clone(),
                 extensions: Some(self.status.as_ref().unwrap().extensions.clone().unwrap()),
             },
         };

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -44,12 +44,12 @@ pub fn default_storage() -> Quantity {
 
 
 pub fn default_sharedir_storage() -> Quantity {
-    Quantity("250Mi".to_string())
+    Quantity("1Gi".to_string())
 }
 
 
 pub fn default_pkglibdir_storage() -> Quantity {
-    Quantity("250Mi".to_string())
+    Quantity("1Gi".to_string())
 }
 
 

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -24,7 +24,7 @@ use k8s_openapi::{
     apimachinery::pkg::util::intstr::IntOrString,
 };
 use std::{collections::BTreeMap, sync::Arc};
-use tracing::info;
+use tracing::{error, info};
 
 const PKGLIBDIR: &str = "/usr/lib/postgresql/15/lib";
 const SHAREDIR: &str = "/usr/share/postgresql/15";
@@ -332,6 +332,7 @@ pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error>
         }
         false => Vec::new(),
     };
+    error!("pvcs_to_update: {:?}", pvcs_to_update);
     if !pvcs_to_update.is_empty() {
         let sts_name = sts.clone().metadata.name.unwrap();
         let sts_namespace = sts.clone().metadata.namespace.unwrap();

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -1,4 +1,8 @@
-use crate::{apis::coredb_types::CoreDB, Context, Error, Result, defaults::default_image, defaults::default_postgres_exporter_image};
+use crate::{
+    apis::coredb_types::CoreDB,
+    defaults::{default_image, default_postgres_exporter_image},
+    Context, Error, Result,
+};
 use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetSpec},

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -24,7 +24,7 @@ use k8s_openapi::{
     apimachinery::pkg::util::intstr::IntOrString,
 };
 use std::{collections::BTreeMap, sync::Arc};
-use tracing::{error, info};
+use tracing::{debug, info};
 
 const PKGLIBDIR: &str = "/usr/lib/postgresql/15/lib";
 const SHAREDIR: &str = "/usr/share/postgresql/15";
@@ -332,7 +332,7 @@ pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error>
         }
         false => Vec::new(),
     };
-    error!("pvcs_to_update: {:?}", pvcs_to_update);
+    debug!("pvcs_to_update: {:?}", pvcs_to_update);
     if !pvcs_to_update.is_empty() {
         let sts_name = sts.clone().metadata.name.unwrap();
         let sts_namespace = sts.clone().metadata.namespace.unwrap();

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -334,7 +334,7 @@ pub async fn reconcile_sts(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error>
     };
     if !pvcs_to_update.is_empty() {
         let sts_name = sts.clone().metadata.name.unwrap();
-        let sts_namespace = &sts.clone().metadata.namespace.unwrap();
+        let sts_namespace = sts.clone().metadata.namespace.unwrap();
 
         // why do delete first, then update?
         delete_sts_no_cascade(&sts_api, &sts_name).await;
@@ -363,7 +363,7 @@ async fn delete_sts_no_cascade(sts_api: &Api<StatefulSet>, sts_name: &str) {
     };
 
     let _o = sts_api
-        .delete(&sts_name, &delete_params)
+        .delete(sts_name, &delete_params)
         .await
         .map_err(Error::KubeError);
 }

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -333,8 +333,8 @@ mod test {
                 "name": name
             },
             "spec": {
-                "pkglibdirStorage": "1000Mi",
-                "sharedirStorage" : "1000Mi"
+                "pkglibdirStorage": "2Gi",
+                "sharedirStorage" : "2Gi"
 
             }
         });
@@ -347,7 +347,7 @@ mod test {
         // https://github.com/rancher/local-path-provisioner/issues/323
         let storage = pvc.spec.unwrap().resources.unwrap().requests.unwrap();
         let s = storage.get("storage").unwrap().to_owned();
-        assert_eq!(Quantity("1000Mi".to_owned()), s);
+        assert_eq!(Quantity("2Gi".to_owned()), s);
     }
 
     #[tokio::test]

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -333,14 +333,18 @@ mod test {
                 "name": name
             },
             "spec": {
-                "pkglibdirStorage": "1000Mi"
+                "pkglibdirStorage": "1000Mi",
+                "sharedirStorage" : "1000Mi"
 
             }
         });
         let params = PatchParams::apply("coredb-integration-test");
         let patch = Patch::Apply(&coredb_json);
         let _ = coredbs.patch(name, &params, &patch).await.unwrap();
+        thread::sleep(Duration::from_millis(10000));
         let pvc = pvc_api.get(&format!("pkglibdir-{}", pod_name)).await.unwrap();
+        // checking that the request is set, but its not the status
+        // https://github.com/rancher/local-path-provisioner/issues/323
         let storage = pvc.spec.unwrap().resources.unwrap().requests.unwrap();
         let s = storage.get("storage").unwrap().to_owned();
         assert_eq!(Quantity("1000Mi".to_owned()), s);


### PR DESCRIPTION
- handle changes to all pvcs, same as we've been doing for the data dir pvc
- all image get set to the operator's default image, rather than the currently set image on the definition
- changed signatures on the stateful set functions to reduce number of `.clone()` that get called