### PR TITLE
[COR-564] Add latest version and timestamps to `/extensions/all`

### DIFF
--- a/trunk/registry/sqlx-data.json
+++ b/trunk/registry/sqlx-data.json
@@ -146,6 +146,26 @@
     },
     "query": "SELECT * FROM extensions WHERE name = $1"
   },
+  "514adcd37018e70d0c1e0ca4c7726d6d4e733d8d3c4c893290bf87eca4452abf": {
+    "describe": {
+      "columns": [
+        {
+          "name": "max",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "SELECT MAX(num) FROM versions WHERE extension_id = $1;"
+  },
   "6cdd35899d214093e96bd8cae07778d12089e0a8712cfe94dc6b747c9b37c3d5": {
     "describe": {
       "columns": [],

--- a/trunk/registry/src/download.rs
+++ b/trunk/registry/src/download.rs
@@ -1,7 +1,9 @@
 //! Functionality for downloading extensions and maintaining download counts
 use crate::config::Config;
+use crate::errors::ExtensionRegistryError;
 use crate::uploader::extension_location;
 use actix_web::{get, web, HttpResponse, Responder};
+use sqlx::{Pool, Postgres};
 
 /// Handles the `GET /extensions/:extension_name/:version/download` route.
 /// This returns a URL to the location where the extension is stored.
@@ -12,4 +14,21 @@ pub async fn download(cfg: web::Data<Config>, path: web::Path<(String, String)>)
     // TODO(ianstanton) Use latest version if none provided
     let url = extension_location(&cfg.bucket_name, &name, &version);
     HttpResponse::Ok().body(url)
+}
+
+pub async fn latest_version(
+    extension_name: &str,
+    conn: web::Data<Pool<Postgres>>,
+) -> Result<String, ExtensionRegistryError> {
+    // Create a transaction on the database, if there are no errors,
+    // commit the transactions to record a new or updated extension.
+    let mut tx = conn.begin().await?;
+    let ext = sqlx::query!("SELECT * FROM extensions WHERE name = $1", extension_name)
+        .fetch_one(&mut tx)
+        .await?;
+    let id: i32 = ext.id as i32;
+    let latest = sqlx::query!("SELECT MAX(num) FROM versions WHERE extension_id = $1;", id)
+        .fetch_one(&mut tx)
+        .await?;
+    Ok(latest.max.unwrap())
 }

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -1,3 +1,4 @@
+use crate::download::latest_version;
 use crate::errors::ExtensionRegistryError;
 use actix_web::{get, web, HttpResponse, Responder};
 use serde_json::{json, Value};
@@ -21,9 +22,12 @@ pub async fn get_all_extensions(
         .fetch_all(&mut tx)
         .await?;
     for row in rows.iter() {
+        let name = row.name.to_owned().unwrap();
+        let latest = latest_version(&name, conn.clone()).await?;
         let data = json!(
         {
           "name": row.name.to_owned(),
+          "latest_version": latest,
           "description": row.description.to_owned(),
           "homepage": row.homepage.to_owned(),
           "documentation": row.documentation.to_owned(),

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -28,6 +28,8 @@ pub async fn get_all_extensions(
         {
           "name": row.name.to_owned(),
           "latestVersion": latest,
+          "createdAt": row.created_at.unwrap().to_string(),
+          "updatedAt": row.updated_at.unwrap().to_string(),
           "description": row.description.to_owned(),
           "homepage": row.homepage.to_owned(),
           "documentation": row.documentation.to_owned(),

--- a/trunk/registry/src/routes.rs
+++ b/trunk/registry/src/routes.rs
@@ -27,7 +27,7 @@ pub async fn get_all_extensions(
         let data = json!(
         {
           "name": row.name.to_owned(),
-          "latest_version": latest,
+          "latestVersion": latest,
           "description": row.description.to_owned(),
           "homepage": row.homepage.to_owned(),
           "documentation": row.documentation.to_owned(),


### PR DESCRIPTION
Add latest version and created / updated timestamp information to `/extensions/all` route. Examples:

```
[
  {
    "createdAt": "2023-03-14 23:35:56.700835",
    "description": "extension",
    "documentation": null,
    "homepage": "coredb.io",
    "latestVersion": "0.1.1",
    "name": "pg_stat_statements",
    "repository": null,
    "updatedAt": "2023-03-15 19:14:04.050032"
  },
  {
    "createdAt": "2023-03-15 19:29:53.983986",
    "description": "extension",
    "documentation": null,
    "homepage": "coredb.io",
    "latestVersion": "0.1.0",
    "name": "steven",
    "repository": null,
    "updatedAt": "2023-03-22 2:43:51.549871"
  },
  {
    "createdAt": "2023-04-04 22:39:42.028416",
    "description": "my new extension",
    "documentation": null,
    "homepage": null,
    "latestVersion": "0.0.3",
    "name": "ian",
    "repository": null,
    "updatedAt": "2023-04-05 1:11:42.11969"
  },
  {
    "createdAt": "2023-03-14 23:34:12.228076",
    "description": "extension",
    "documentation": null,
    "homepage": "coredb.io",
    "latestVersion": "0.2.3",
    "name": "pgmq",
    "repository": null,
    "updatedAt": "2023-04-05 15:43:02.787269"
  }
]
```

Related to:
- https://github.com/CoreDB-io/coredb/issues/213