### PR TITLE
[COR-381] `trunk publish`

### DIFF
--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = "0.3.26"
 hyper = "0.14.24"
 rand = "0.8.5"
 read-write-pipe = "0.1.0"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.16", features = ["multipart"] }
 semver = "1.0.16"
 serde = { version = "1.0.153", features = ["derive"] }
 serde_json = "1.0.91"

--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pg-trunk"
-version = "0.0.1-alpha.4"
+version = "0.1.0"
 edition = "2021"
-authors = ["Steven Miller"]
+authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"
 homepage = "https://trnk.io"
 license = "Apache-2.0"

--- a/trunk/cli/src/commands/publish.rs
+++ b/trunk/cli/src/commands/publish.rs
@@ -1,15 +1,46 @@
+use std::fs;
+use std::path::PathBuf;
 use super::SubCommand;
 use async_trait::async_trait;
 use clap::Args;
+use hyper::header::CONTENT_TYPE;
+use reqwest::header::HeaderMap;
 use tokio_task_manager::Task;
 
 #[derive(Args)]
-pub struct PublishCommand {}
+pub struct PublishCommand {
+    name: String,
+    #[arg(long = "version", short = 'v')]
+    version: String,
+    #[arg(long = "file", short = 'f')]
+    file: Option<PathBuf>,
+    #[arg(long = "description", short = 'd')]
+    description: Option<String>,
+    #[arg(long = "documentation", short = 'D')]
+    documentation: Option<String>,
+    #[arg(long = "license", short = 'l')]
+    license: Option<String>,
+    #[arg(long = "registry", short = 'r', default_value = "https://pgtrunk.io")]
+    registry: String,
+    #[arg(long = "repository", short = 'R')]
+    repository: Option<String>,
+}
 
 #[async_trait]
 impl SubCommand for PublishCommand {
     async fn execute(&self, _task: Task) -> Result<(), anyhow::Error> {
-        println!("trunk publish: not implemented");
+        if let Some(ref file) = self.file {
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_TYPE, "application/octet-stream".parse().unwrap());
+            let file = fs::read(file).unwrap();
+            let file_part = reqwest::multipart::Part::bytes(file).file_name("pgmq-0.2.1.tar.gz").headers(headers);
+            let metadata = reqwest::multipart::Part::text("{\"name\": \"pgmq\", \"vers\": \"0.2.1\", \"description\": \"A lightweight distributed message queue. Like AWS SQS and RSMQ but on Postgres.\", \"documentation\": null, \"license\": \"Apache-2.0\", \"repository\": \"https://github.com/CoreDB-io/coredb/tree/main/extensions/pgmq\"}");
+            let form = reqwest::multipart::Form::new().part("metadata", metadata).part("file", file_part);
+            let client = reqwest::Client::new();
+            let url = format!("{}/extensions/new", self.registry);
+            let res = client.post(url).multipart(form).send().await?;
+            println!("RES: {:?}", res);
+        }
         Ok(())
     }
 }

--- a/trunk/cli/src/commands/publish.rs
+++ b/trunk/cli/src/commands/publish.rs
@@ -37,38 +37,55 @@ pub enum PublishError {
 #[async_trait]
 impl SubCommand for PublishCommand {
     async fn execute(&self, _task: Task) -> Result<(), anyhow::Error> {
-        if let Some(ref file) = self.file {
-            check_input(&self.name)?;
-            let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/octet-stream".parse().unwrap());
-            let file = fs::read(file).unwrap();
-            let file_part = reqwest::multipart::Part::bytes(file)
-                .file_name("pgmq-0.2.1.tar.gz")
-                .headers(headers);
-            let m = json!({
-                "name": self.name,
-                "vers": self.version,
-                "description": self.description,
-                "documentation": self.documentation,
-                "license": self.license,
-                "repository": self.repository
-            });
-            let metadata = reqwest::multipart::Part::text(m.to_string());
-            let form = reqwest::multipart::Form::new()
-                .part("metadata", metadata)
-                .part("file", file_part);
-            let client = reqwest::Client::new();
-            let url = format!("{}/extensions/new", self.registry);
-            let res = client
-                .post(url)
-                .multipart(form)
-                .send()
-                .await?
-                .text()
-                .await?;
-            // print response from registry
-            println!("{}", res)
-        }
+        // Validate extension name input
+        check_input(&self.name)?;
+        let (file, name) = match &self.file {
+            Some(..) => {
+                // If file is specified, use it
+                let path = self.file.clone().unwrap();
+                let name = path.file_name().unwrap().to_str().unwrap().to_owned();
+                let f = fs::read(self.file.clone().unwrap())?;
+                (f, name)
+            }
+            None => {
+                // If no file is specified, read file from working dir with format
+                // <extension_name>-<version>.tar.gz.
+                // Error if file is not found
+                let mut path = PathBuf::new();
+                let _ = &path.push(format!("./{}-{}.tar.gz", self.name, self.version));
+                let name = path.file_name().unwrap().to_str().unwrap().to_owned();
+                let f = fs::read(path.clone())?;
+                (f, name)
+            }
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, "application/octet-stream".parse().unwrap());
+        let file_part = reqwest::multipart::Part::bytes(file)
+            .file_name(name)
+            .headers(headers);
+        let m = json!({
+            "name": self.name,
+            "vers": self.version,
+            "description": self.description,
+            "documentation": self.documentation,
+            "license": self.license,
+            "repository": self.repository
+        });
+        let metadata = reqwest::multipart::Part::text(m.to_string());
+        let form = reqwest::multipart::Form::new()
+            .part("metadata", metadata)
+            .part("file", file_part);
+        let client = reqwest::Client::new();
+        let url = format!("{}/extensions/new", self.registry);
+        let res = client
+            .post(url)
+            .multipart(form)
+            .send()
+            .await?
+            .text()
+            .await?;
+        // Print response from registry
+        println!("{}", res);
         Ok(())
     }
 }

--- a/trunk/cli/src/commands/publish.rs
+++ b/trunk/cli/src/commands/publish.rs
@@ -1,11 +1,12 @@
-use std::fs;
-use std::path::PathBuf;
 use super::SubCommand;
+use crate::commands::publish::PublishError::InvalidExtensionName;
 use async_trait::async_trait;
 use clap::Args;
 use hyper::header::CONTENT_TYPE;
 use reqwest::header::HeaderMap;
 use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
 use tokio_task_manager::Task;
 
 #[derive(Args)]
@@ -27,14 +28,23 @@ pub struct PublishCommand {
     repository: Option<String>,
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum PublishError {
+    #[error("extension name can include alphanumeric characters and underscores")]
+    InvalidExtensionName,
+}
+
 #[async_trait]
 impl SubCommand for PublishCommand {
     async fn execute(&self, _task: Task) -> Result<(), anyhow::Error> {
         if let Some(ref file) = self.file {
+            check_input(&self.name)?;
             let mut headers = HeaderMap::new();
             headers.insert(CONTENT_TYPE, "application/octet-stream".parse().unwrap());
             let file = fs::read(file).unwrap();
-            let file_part = reqwest::multipart::Part::bytes(file).file_name("pgmq-0.2.1.tar.gz").headers(headers);
+            let file_part = reqwest::multipart::Part::bytes(file)
+                .file_name("pgmq-0.2.1.tar.gz")
+                .headers(headers);
             let m = json!({
                 "name": self.name,
                 "vers": self.version,
@@ -44,12 +54,32 @@ impl SubCommand for PublishCommand {
                 "repository": self.repository
             });
             let metadata = reqwest::multipart::Part::text(m.to_string());
-            let form = reqwest::multipart::Form::new().part("metadata", metadata).part("file", file_part);
+            let form = reqwest::multipart::Form::new()
+                .part("metadata", metadata)
+                .part("file", file_part);
             let client = reqwest::Client::new();
             let url = format!("{}/extensions/new", self.registry);
-            let res = client.post(url).multipart(form).send().await?;
-            println!("RES: {:?}", res);
+            let res = client
+                .post(url)
+                .multipart(form)
+                .send()
+                .await?
+                .text()
+                .await?;
+            // print response from registry
+            println!("{}", res)
         }
         Ok(())
+    }
+}
+
+pub fn check_input(input: &str) -> Result<(), PublishError> {
+    let valid = input
+        .as_bytes()
+        .iter()
+        .all(|&c| c.is_ascii_alphanumeric() || c == b'_');
+    match valid {
+        true => Ok(()),
+        false => Err(InvalidExtensionName),
     }
 }


### PR DESCRIPTION
`trunk publish` allows for publishing postgres extensions to the trunk registry. If no file is provided, the CLI will look for a file in its working dir with format `<extension_name>-<version>.tar.gz`.
Example:
```
❯ trunk publish test_trunk --version 0.0.1 -f ./test_trunk-0.0.1.tar.gz --registry https://dev.server.com
Successfully published extension test_trunk version 0.0.1
```