### PR TITLE
add trunk to pg image

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb"
-version = "15.2.0-coredb.3"
+version = "15.2.0-coredb.4"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.1 as builder
+FROM rust:bookworm as builder
 RUN cargo install --version 0.0.1-alpha.4 pg-trunk
 
 FROM ubuntu:22.04

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,9 @@
+FROM rust:1.66.1 as builder
+RUN cargo install --version 0.0.1-alpha.4 pg-trunk
+
 FROM ubuntu:22.04
+
+COPY --from=builder /usr/local/cargo/bin/trunk /usr/bin/trunk
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC


### PR DESCRIPTION
trunk needs to be compiled against same version of open ssl that it will use at runtime.

Using the `bookworm` rust image in the builder since its running openssl 3. ubuntu 22.04 also runs openssl 3. instead of installing openssl 1 in the ubuntu layer, let's just compile it against openssl 3 to begin with.