### PR TITLE
Fix typos

### DIFF
--- a/.github/actions/build-and-push-to-quay/action.yml
+++ b/.github/actions/build-and-push-to-quay/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: true
     description: "Quay 'robot user' access token"
   publish_calver:
-    description: 'Should we tag with calender versioning?'
+    description: 'Should we tag with calendar versioning?'
     required: false
     default: false
   calver_suffix:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -35,8 +35,8 @@ jobs:
   cargo_publish:
     # On a pull request, this is validating that the version
     # is not already published to crates.io, and on a push to
-    # main or release branches, it is publishing if the verison
-    # does not exist, ignoring if the verison is already
+    # main or release branches, it is publishing if the version
+    # does not exist, ignoring if the version is already
     # published.
     name: Cargo publish or validate
     runs-on: ubuntu-20.04

--- a/coredb-cli/LICENSE
+++ b/coredb-cli/LICENSE
@@ -93,7 +93,7 @@ whose behalf you are receiving the Software.
       Agreement will be referred to and finally determined by arbitration in
       accordance with the JAMS International Arbitration Rules.  The tribunal
       will consist of one arbitrator.  The place of arbitration will be Palo
-      Alto, California. The language to be used in the arbitral proceedings
+      Alto, California. The language to be used in the arbitrary proceedings
       will be English.  Judgment upon the award rendered by the arbitrator may
       be entered in any court having jurisdiction thereof.
 

--- a/coredb-operator/LICENSE
+++ b/coredb-operator/LICENSE
@@ -93,7 +93,7 @@ whose behalf you are receiving the Software.
       Agreement will be referred to and finally determined by arbitration in
       accordance with the JAMS International Arbitration Rules.  The tribunal
       will consist of one arbitrator.  The place of arbitration will be Palo
-      Alto, California. The language to be used in the arbitral proceedings
+      Alto, California. The language to be used in the arbitrary proceedings
       will be English.  Judgment upon the award rendered by the arbitrator may
       be entered in any court having jurisdiction thereof.
 

--- a/crates/pgmq/src/lib.rs
+++ b/crates/pgmq/src/lib.rs
@@ -268,7 +268,7 @@ impl PGMQueue {
     /// }
     pub async fn destroy(&self, queue_name: &str) -> Result<(), errors::PgmqError> {
         let mut tx = self.connection.begin().await?;
-        let setup = query::destory_queue(queue_name)?;
+        let setup = query::destroy_queue(queue_name)?;
         for q in setup {
             sqlx::query(&q).execute(&mut tx).await?;
         }
@@ -704,7 +704,7 @@ impl PGMQueue {
     ///         .await
     ///         .expect("Failed to create queue");
     ///
-    ///     let msgs = vec![  
+    ///     let msgs = vec![
     ///         serde_json::json!({"foo": "bar1"}),
     ///         serde_json::json!({"foo": "bar2"}),
     ///         serde_json::json!({"foo": "bar3"}),

--- a/crates/pgmq/src/query.rs
+++ b/crates/pgmq/src/query.rs
@@ -14,7 +14,7 @@ pub fn init_queue(name: &str) -> Result<Vec<String>, PgmqError> {
     ])
 }
 
-pub fn destory_queue(name: &str) -> Result<Vec<String>, PgmqError> {
+pub fn destroy_queue(name: &str) -> Result<Vec<String>, PgmqError> {
     check_input(name)?;
     Ok(vec![
         drop_queue(name)?,
@@ -139,7 +139,7 @@ pub fn enqueue(
     messages: &[serde_json::Value],
     delay: &u64,
 ) -> Result<String, PgmqError> {
-    // TOOO: vt should be now() + delay
+    // TODO: vt should be now() + delay
     // construct string of comma separated messages
     check_input(name)?;
     let mut values: String = "".to_owned();
@@ -174,7 +174,7 @@ pub fn read(name: &str, vt: &i32, limit: &i32) -> Result<String, PgmqError> {
             FOR UPDATE SKIP LOCKED
         )
     UPDATE {TABLE_PREFIX}_{name}
-    SET 
+    SET
         vt = (now() at time zone 'utc' + interval '{vt} seconds'),
         read_ct = read_ct + 1
     WHERE msg_id in (select msg_id from cte)
@@ -221,7 +221,7 @@ pub fn archive(name: &str, msg_id: &i64) -> Result<String, PgmqError> {
             RETURNING msg_id, vt, read_ct, enqueued_at, message
         )
         INSERT INTO {TABLE_PREFIX}_{name}_archive (msg_id, vt, read_ct, enqueued_at, message)
-        SELECT msg_id, vt, read_ct, enqueued_at, message 
+        SELECT msg_id, vt, read_ct, enqueued_at, message
         FROM archived;
         "
     ))

--- a/crates/pgmq/tests/integration_test.rs
+++ b/crates/pgmq/tests/integration_test.rs
@@ -542,11 +542,11 @@ async fn test_database_error_modes() {
                 panic!("expected a url parsing error, got {:?}", e);
             }
         }
-        // didnt get an error. bad.
+        // didn't get an error. bad.
         _ => panic!("expected a url parsing error, got {:?}", read_msg),
     }
 
-    // connect to a postgres instance that doesnt exist should error
+    // connect to a postgres instance that doesn't exist should error
     let queue = pgmq::PGMQueue::new("postgres://user:pass@badhost:5432".to_owned()).await;
     // we expect a database error
     match queue {
@@ -558,7 +558,7 @@ async fn test_database_error_modes() {
                 panic!("expected a db error, got {:?}", e);
             }
         }
-        // didnt get an error. bad.
+        // didn't get an error. bad.
         _ => panic!("expected a db error, got {:?}", read_msg),
     }
 }
@@ -584,7 +584,7 @@ async fn test_parsing_error_modes() {
                 panic!("expected a parse error, got {:?}", e);
             }
         }
-        // didnt get an error. bad.
+        // didn't get an error. bad.
         _ => panic!("expected a parse error, got {:?}", read_msg),
     }
 }

--- a/extensions/pgmq/examples/ruby.rb
+++ b/extensions/pgmq/examples/ruby.rb
@@ -59,7 +59,7 @@ $stderr.puts '---',
   "### msg ###",
   "msg_id: #{msg_row['msg_id']}, value: #{JSON.parse(msg_row['message']).to_s}"
 
-# delete a mesage (for a given ID)
+# delete a message (for a given ID)
 msg_result = conn.exec( "select pgmq_delete('#{QUEUE_NAME}', #{msg_id})" )
 $stderr.puts '---',
   "### msg delete: #{msg_id} ###",

--- a/extensions/pgmq/src/lib.rs
+++ b/extensions/pgmq/src/lib.rs
@@ -57,7 +57,7 @@ fn pgmq_send(queue_name: &str, message: pgx::JsonB) -> Result<Option<i64>, PgmqE
 
 fn enqueue_str(name: &str, message: &str) -> Result<String, PgmqError> {
     check_input(name)?;
-    // TOOO: vt should be now() + delay
+    // TODO: vt should be now() + delay
     Ok(format!(
         "
         INSERT INTO {TABLE_PREFIX}_{name} (vt, message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "coredb"
 version = "0.1.0"
-description = "Depdencies for CoreDb MkDocs"
+description = "Dependencies for CoreDb MkDocs"
 authors = ["Coredb Admin <admin@coredb.io>"]
 readme = "README.md"
 


### PR DESCRIPTION
Found via `codespell -S .git -L crate,bu,vew,astroid,ser,dne,pring`