### PR TITLE
Bump pgmq extension dependency to 0.10.1

### DIFF
--- a/extensions/pgmq/Cargo.lock
+++ b/extensions/pgmq/Cargo.lock
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
- "pgmq 0.8.1",
+ "pgmq 0.10.1",
  "pgx",
  "pgx-tests",
  "serde",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.8.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6975ba33a7c9af421ea36f98b0fbc480327f6709f786c76d566e62f86ec110"
+checksum = "9e5588b0cc388f3e42d2e1ff83bc1d43b423b4932ca33882d0374f16713b8c14"
 dependencies = [
  "chrono",
  "log",

--- a/extensions/pgmq/Cargo.toml
+++ b/extensions/pgmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"
@@ -25,7 +25,7 @@ pg_test = []
 [dependencies]
 pgx = "0.7.1"
 serde = "1.0.152"
-pgmq_crate = { package = "pgmq", version = "0.8.1" }
+pgmq_crate = { package = "pgmq", version = "0.10.1" }
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 


### PR DESCRIPTION
Bump pgmq extension's crate dependency to latest (`0.10.1`).