### PR TITLE
[COR-614] Add homepage as `trunk publish` flag

### DIFF
--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/trunk/cli/src/commands/install.rs
+++ b/trunk/cli/src/commands/install.rs
@@ -19,7 +19,7 @@ pub struct InstallCommand {
     file: Option<PathBuf>,
     #[arg(long = "version", short = 'v')]
     version: String,
-    #[arg(long = "registry", short = 'r', default_value = "https://pgtrunk.io")]
+    #[arg(long = "registry", short = 'r', default_value = "https://registry.pgtrunk.io")]
     registry: String,
 }
 

--- a/trunk/cli/src/commands/publish.rs
+++ b/trunk/cli/src/commands/publish.rs
@@ -20,6 +20,8 @@ pub struct PublishCommand {
     description: Option<String>,
     #[arg(long = "documentation", short = 'D')]
     documentation: Option<String>,
+    #[arg(long = "homepage", short = 'H')]
+    homepage: Option<String>,
     #[arg(long = "license", short = 'l')]
     license: Option<String>,
     #[arg(long = "registry", short = 'r', default_value = "https://pgtrunk.io")]
@@ -68,6 +70,7 @@ impl SubCommand for PublishCommand {
             "vers": self.version,
             "description": self.description,
             "documentation": self.documentation,
+            "homepage": self.homepage,
             "license": self.license,
             "repository": self.repository
         });


### PR DESCRIPTION
- Add `homepage` as `trunk publish` flag
- Update default registry url to `https://registry.pgtrunk.io`