### PR TITLE
Update default registry url in `trunk publish`

### DIFF
--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/trunk/cli/README.md
+++ b/trunk/cli/README.md
@@ -40,7 +40,7 @@ This purpose-built registry would provide a centralized location for developers 
 
 ### The Website
 
-We will launch a website ([code being built here](https://github.com/coreDB-io/pgtrunk.io)) to help developers both discover and learn about extensions. This website is key to our success, as it will drive attention, traffic, etc, and lead users to the CLI tool.
+We will launch a [website](https://pgtrunk.io) to help developers both discover and learn about extensions. This website is key to our success, as it will drive attention, traffic, etc, and lead users to the CLI tool.
 
 Features will include:
 

--- a/trunk/cli/src/commands/install.rs
+++ b/trunk/cli/src/commands/install.rs
@@ -19,7 +19,11 @@ pub struct InstallCommand {
     file: Option<PathBuf>,
     #[arg(long = "version", short = 'v')]
     version: String,
-    #[arg(long = "registry", short = 'r', default_value = "https://registry.pgtrunk.io")]
+    #[arg(
+        long = "registry",
+        short = 'r',
+        default_value = "https://registry.pgtrunk.io"
+    )]
     registry: String,
 }
 

--- a/trunk/cli/src/commands/publish.rs
+++ b/trunk/cli/src/commands/publish.rs
@@ -24,7 +24,11 @@ pub struct PublishCommand {
     homepage: Option<String>,
     #[arg(long = "license", short = 'l')]
     license: Option<String>,
-    #[arg(long = "registry", short = 'r', default_value = "https://pgtrunk.io")]
+    #[arg(
+        long = "registry",
+        short = 'r',
+        default_value = "https://registry.pgtrunk.io"
+    )]
     registry: String,
     #[arg(long = "repository", short = 'R')]
     repository: Option<String>,


### PR DESCRIPTION
- Followup to https://github.com/CoreDB-io/coredb/pull/238, update default registry URL in publish command
- Link to https://pgtrunk.io/ in README