### PR TITLE
comment out auth on trunk ui

### DIFF
--- a/trunk/trunk-ui/components/Header/index.tsx
+++ b/trunk/trunk-ui/components/Header/index.tsx
@@ -24,7 +24,7 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <h1 className={cx(inter.className, styles.title)}>Trunk</h1>
-      {user ? (
+      {/* {user ? (
         <button onClick={() => signOut()} className={styles.loginButton}>
           <Image src="/images/github.svg" alt="GitHub logo" width={20} height={20}></Image>
           <span className={cx(inter.className, styles.authText, styles.userName)}>{user.fullName}</span>
@@ -35,7 +35,7 @@ export default function Header() {
           <Image src="/images/github.svg" alt="GitHub logo" width={20} height={20}></Image>
           <span className={cx(inter.className, styles.authText)}>Sign in with GitHub</span>
         </button>
-      )}
+      )} */}
     </header>
   );
 }


### PR DESCRIPTION
Temporarily disable auth on trunk landing page since there currently isn't any auth related functionality. This will be added back in once we have a "user profile" page.