### PR TITLE
Bump pgx vers trunk

### DIFF
--- a/examples/create-extension/my_extension/Cargo.toml
+++ b/examples/create-extension/my_extension/Cargo.toml
@@ -17,10 +17,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.2"
+pgx = "=0.7.4"
 
 [dev-dependencies]
-pgx-tests = "=0.7.2"
+pgx-tests = "=0.7.4"
 
 [profile.dev]
 panic = "unwind"

--- a/examples/create-extension/my_extension/Cargo.toml
+++ b/examples/create-extension/my_extension/Cargo.toml
@@ -17,10 +17,10 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.7.4"
+pgx = "=0.7.2"
 
 [dev-dependencies]
-pgx-tests = "=0.7.4"
+pgx-tests = "=0.7.2"
 
 [profile.dev]
 panic = "unwind"

--- a/trunk/cli/.github/workflows/images.yaml
+++ b/trunk/cli/.github/workflows/images.yaml
@@ -18,6 +18,8 @@ jobs:
         pgx_version:
           - "0.7.1"
           - "0.7.2"
+          - "0.7.3"
+          - "0.7.4"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.3.1"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"
-homepage = "https://trnk.io"
+homepage = "https://pgtrunk.io"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/coredb-io/trunk"
+repository = "https://github.com/coredb-io/coredb"
 
 [[bin]]
 name = "trunk"

--- a/trunk/cli/Cargo.toml
+++ b/trunk/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/trunk/cli/src/commands/pgx.rs
+++ b/trunk/cli/src/commands/pgx.rs
@@ -68,7 +68,7 @@ pub enum PgxBuildError {
 }
 
 fn semver_from_range(pgx_range: &str) -> Result<String, PgxBuildError> {
-    let versions = ["0.7.2", "0.7.1"];
+    let versions = ["0.7.4", "0.7.3", "0.7.2", "0.7.1"];
 
     if versions.contains(&pgx_range) {
         // If the input is already a specific version, return it as-is
@@ -419,6 +419,6 @@ mod tests {
     fn test_semver_from_range_semver_range() {
         // Test that a semver range is converted to the highest matching version
         let result = semver_from_range(">=0.7.1, <0.8.0");
-        assert_eq!(result.unwrap(), "0.7.2");
+        assert_eq!(result.unwrap(), "0.7.4");
     }
 }


### PR DESCRIPTION
`trunk build` fails in our example extension project due to `pgx` version:
```
Building from path .
Detected that we are building a pgx extension
Detected pgx version range =0.7.4
thread 'main' panicked at 'error occurred: Cargo manifest error: No supported version of pgx satisfies the range =0.7.4. 
Supported versions: ["0.7.2", "0.7.1"]', /home/ian/.cargo/registry/src/github.com-1ecc6299db9ec823/pg-trunk-0.2.1/src/main.rs:51:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We can either bump supported versions (this PR), or dial back the example version to `0.7.2`.