### PR TITLE
[pgmq] enforce retention on stale partitions 

### DIFF
--- a/pgmq/core/Cargo.toml
+++ b/pgmq/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq/core/Cargo.toml
+++ b/pgmq/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq/core/src/lib.rs
+++ b/pgmq/core/src/lib.rs
@@ -950,7 +950,8 @@ pub fn conn_options(url: &str) -> Result<PgConnectOptions, ParseError> {
         .host(parsed.host_str().ok_or(ParseError::EmptyHost)?)
         .port(parsed.port().ok_or(ParseError::InvalidPort)?)
         .username(parsed.username())
-        .password(parsed.password().ok_or(ParseError::IdnaError)?);
+        .password(parsed.password().ok_or(ParseError::IdnaError)?)
+        .database(parsed.path().trim_start_matches('/'));
     options.log_statements(LevelFilter::Debug);
     Ok(options)
 }

--- a/pgmq/core/src/lib.rs
+++ b/pgmq/core/src/lib.rs
@@ -881,7 +881,7 @@ impl PGMQueue {
 // Executes a query and returns a single row
 // If the query returns no rows, None is returned
 // This function is intended for internal use.
-async fn fetch_one_message<T: for<'de> Deserialize<'de>>(
+pub async fn fetch_one_message<T: for<'de> Deserialize<'de>>(
     query: &str,
     connection: &Pool<Postgres>,
 ) -> Result<Option<Message<T>>, errors::PgmqError> {

--- a/pgmq/core/src/query.rs
+++ b/pgmq/core/src/query.rs
@@ -246,7 +246,7 @@ pub fn pop(name: &str) -> Result<String, PgmqError> {
         "
         WITH cte AS
             (
-                SELECT *
+                SELECT msg_id
                 FROM {TABLE_PREFIX}_{name}
                 WHERE vt <= now() at time zone 'utc'
                 ORDER BY msg_id ASC

--- a/pgmq/core/src/query.rs
+++ b/pgmq/core/src/query.rs
@@ -130,7 +130,7 @@ pub fn create_index(name: &str) -> Result<String, PgmqError> {
     check_input(name)?;
     Ok(format!(
         "
-        CREATE INDEX IF NOT EXISTS vt_idx_{name} ON {TABLE_PREFIX}_{name} (vt ASC);
+        CREATE INDEX IF NOT EXISTS vt_idx_{name} ON {TABLE_PREFIX}_{name} (vt ASC) INCLUDE (msg_id);
         "
     ))
 }
@@ -166,7 +166,7 @@ pub fn read(name: &str, vt: &i32, limit: &i32) -> Result<String, PgmqError> {
         "
     WITH cte AS
         (
-            SELECT *
+            SELECT msg_id
             FROM {TABLE_PREFIX}_{name}
             WHERE vt <= now() at time zone 'utc'
             ORDER BY msg_id ASC

--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 name = "pgmq"
 version = "0.2.1"
 dependencies = [
- "pgmq 0.8.1",
+ "pgmq 0.10.1",
  "pgx",
  "pgx-tests",
  "serde",
@@ -1141,9 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6975ba33a7c9af421ea36f98b0fbc480327f6709f786c76d566e62f86ec110"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "log",

--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
- "pgmq 0.10.1",
+ "pgmq 0.11.0",
  "pgx",
  "pgx-tests",
  "serde",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "log",

--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1134,9 +1134,12 @@ dependencies = [
  "pgmq 0.11.0",
  "pgx",
  "pgx-tests",
+ "rand",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1131,11 +1131,7 @@ dependencies = [
 name = "pgmq"
 version = "0.4.0"
 dependencies = [
-<<<<<<< HEAD
- "pgmq 0.11.0",
-=======
- "pgmq 0.10.1",
->>>>>>> main
+ "pgmq 0.11.1",
  "pgx",
  "pgx-tests",
  "rand",
@@ -1149,11 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-<<<<<<< HEAD
-version = "0.11.0"
-=======
-version = "0.10.1"
->>>>>>> main
+version = "0.11.1"
 dependencies = [
  "chrono",
  "log",

--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "whoami",
 ]
 
 [[package]]
@@ -2361,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
+checksum = "2c70234412ca409cc04e864e89523cb0fc37f5e1344ebed5a3ebf4192b6b9f68"
 dependencies = [
  "wasm-bindgen",
  "web-sys",

--- a/pgmq/extension/Cargo.toml
+++ b/pgmq/extension/Cargo.toml
@@ -34,6 +34,7 @@ pgx-tests = "0.7.4"
 rand = "0.8.5"
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
 tokio = { version = "1", features = ["macros"] }
+whoami = "1.4.0"
 
 [profile.dev]
 panic = "unwind"

--- a/pgmq/extension/Cargo.toml
+++ b/pgmq/extension/Cargo.toml
@@ -25,12 +25,15 @@ pg_test = []
 [dependencies]
 pgx = "0.7.4"
 serde = "1.0.152"
-pgmq_crate = { package = "pgmq", path = "../core"}
+pgmq_crate = {package = "pgmq", path = "../core"}
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 
 [dev-dependencies]
 pgx-tests = "0.7.4"
+rand = "0.8.5"
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres", "chrono" ] }
+tokio = { version = "1", features = ["macros"] }
 
 [profile.dev]
 panic = "unwind"

--- a/pgmq/extension/Cargo.toml
+++ b/pgmq/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"

--- a/pgmq/extension/Cargo.toml
+++ b/pgmq/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"

--- a/pgmq/extension/README.md
+++ b/pgmq/extension/README.md
@@ -54,7 +54,7 @@ psql postgres://postgres:postgres@0.0.0.0:5432/postgres
 ```
 
 ```sql
--- create the extension
+-- create the extension, pg_partman is also required
 CREATE EXTENSION pgmq CASCADE;
 ```
 

--- a/pgmq/extension/README.md
+++ b/pgmq/extension/README.md
@@ -4,19 +4,20 @@ A lightweight distributed message queue. Like [AWS SQS](https://aws.amazon.com/s
 
 ## Features
 
-- Lightweight - Rust and Postgres only
-- Guaranteed delivery of messages to exactly one consumer within a visibility timeout
+- Lightweight - Built with Rust and Postgres only
+- Guaranteed delivery of messages to `exactly one` consumer within a visibility timeout
 - API parity with [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq)
 - Messages stay in the queue until deleted
 - Messages can be archived, instead of deleted, for long-term retention and replayability
-- Completely asynchronous API
-
+- Table maintenance (bloat) automated with [pg_partman]()
+- High performance operations with index-only scans.
+  
 ## Table of Contents
 - [Postgres Message Queue (PGMQ)](#postgres-message-queue-pgmq)
   - [Features](#features)
   - [Table of Contents](#table-of-contents)
-  - [Start CoreDB Postgres](#start-coredb-postgres)
-  - [Python Examples](#python-examples)
+  - [Installation](#installation)
+  - [Client Libraries](#client-libraries)
   - [SQL Examples](#sql-examples)
     - [Creating a queue](#creating-a-queue)
     - [Send two message](#send-two-message)
@@ -30,19 +31,19 @@ A lightweight distributed message queue. Like [AWS SQS](https://aws.amazon.com/s
 - [Configuration](#configuration)
   - [Partitioned Queues](#partitioned-queues)
 
-## Start CoreDB Postgres
+## Installation
 
-CoreDB Postgres images come with the `pgmq` extension pre-installed.
-
+The fastest way to get started is by running the CoreDB docker image, where PGMQ comes pre-installed.
 
 ```bash
 docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/coredb/postgres:latest
 ```
 
-## Python Examples
+## Client Libraries
 
 
-See python examples in [examples/python.py](examples/python.py)
+- [Rust](https://github.com/CoreDB-io/coredb/tree/main/pgmq/core)
+- [Python](https://github.com/CoreDB-io/coredb/tree/main/pgmq/coredb-pgmq-python)
 
 ## SQL Examples
 

--- a/pgmq/extension/pgmq.control
+++ b/pgmq/extension/pgmq.control
@@ -1,4 +1,4 @@
-comment = 'pgmq: distributed message queues'
+comment = 'Distributed message queues'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pgmq'
 relocatable = false

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -36,8 +36,8 @@ fn pgmq_create_non_partitioned(queue_name: &str) -> Result<(), PgmqExtError> {
 #[pg_extern]
 fn pgmq_create(
     queue_name: &str,
-    partition_interval: default!(String, "daily"),
-    retention_interval: default!(String, "daily"),
+    partition_interval: default!(String, "'daily'"),
+    retention_interval: default!(String, "'7 days'"),
 ) -> Result<(), PgmqExtError> {
     let setup =
         partition::init_partitioned_queue(queue_name, &partition_interval, &retention_interval)?;

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -37,7 +37,7 @@ fn pgmq_create_non_partitioned(queue_name: &str) -> Result<(), PgmqExtError> {
 fn pgmq_create(
     queue_name: &str,
     partition_interval: default!(String, "'daily'"),
-    retention_interval: default!(String, "'7 days'"),
+    retention_interval: default!(String, "'5 days'"),
 ) -> Result<(), PgmqExtError> {
     let setup =
         partition::init_partitioned_queue(queue_name, &partition_interval, &retention_interval)?;

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -22,7 +22,7 @@ enum PgmqExtError {
 }
 
 #[pg_extern]
-fn pgmq_create(queue_name: &str) -> Result<(), PgmqExtError> {
+fn pgmq_create_non_partitioned(queue_name: &str) -> Result<(), PgmqExtError> {
     let setup = init_queue(queue_name)?;
     let ran: Result<_, spi::Error> = Spi::connect(|mut c| {
         for q in setup {
@@ -34,7 +34,7 @@ fn pgmq_create(queue_name: &str) -> Result<(), PgmqExtError> {
 }
 
 #[pg_extern]
-fn pgmq_create_partitioned(
+fn pgmq_create(
     queue_name: &str,
     partition_interval: default!(String, "daily"),
     retention_interval: default!(String, "daily"),
@@ -278,9 +278,9 @@ mod tests {
     use pgmq_crate::query::TABLE_PREFIX;
 
     #[pg_test]
-    fn test_create() {
+    fn test_creat_non_partitioned() {
         let qname = r#"test_queue"#;
-        let _ = pgmq_create(&qname).unwrap();
+        let _ = pgmq_create_non_partitioned(&qname).unwrap();
         let retval = Spi::get_one::<i64>(&format!("SELECT count(*) FROM {TABLE_PREFIX}_{qname}"))
             .expect("SQL select failed");
         assert_eq!(retval.unwrap(), 0);
@@ -294,7 +294,7 @@ mod tests {
     #[pg_test]
     fn test_default() {
         let qname = r#"test_default"#;
-        let _ = pgmq_create(&qname);
+        let _ = pgmq_create_non_partitioned(&qname);
         let init_count =
             Spi::get_one::<i64>(&format!("SELECT count(*) FROM {TABLE_PREFIX}_{qname}"))
                 .expect("SQL select failed");
@@ -322,7 +322,7 @@ mod tests {
     #[pg_test]
     fn test_internal() {
         let qname = r#"test_internal"#;
-        let _ = pgmq_create(&qname).unwrap();
+        let _ = pgmq_create_non_partitioned(&qname).unwrap();
 
         let queues = listit().unwrap();
         assert_eq!(queues.len(), 1);
@@ -379,7 +379,7 @@ mod tests {
         let partition_interval = "2".to_owned();
         let retention_interval = "2".to_owned();
 
-        let _ = pgmq_create_partitioned(&qname, partition_interval, retention_interval).unwrap();
+        let _ = pgmq_create(&qname, partition_interval, retention_interval).unwrap();
 
         let queues = listit().unwrap();
         assert_eq!(queues.len(), 1);
@@ -431,7 +431,7 @@ mod tests {
     #[pg_test]
     fn test_archive() {
         let qname = r#"test_archive"#;
-        let _ = pgmq_create(&qname).unwrap();
+        let _ = pgmq_create_non_partitioned(&qname).unwrap();
         // no messages in the queue
         let retval = Spi::get_one::<i64>(&format!("SELECT count(*) FROM {TABLE_PREFIX}_{qname}"))
             .expect("SQL select failed");

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -37,6 +37,7 @@ fn pgmq_create(queue_name: &str) -> Result<(), PgmqExtError> {
 fn pgmq_create_partitioned(
     queue_name: &str,
     partition_size: default!(i64, 10000),
+    retention_size: default!(i64, 10000),
 ) -> Result<(), PgmqExtError> {
     let setup = partition::init_partitioned_queue(queue_name, partition_size)?;
     let ran: Result<_, spi::Error> = Spi::connect(|mut c| {
@@ -374,7 +375,7 @@ mod tests {
     fn test_partitioned() {
         let qname = r#"test_internal"#;
 
-        let _ = pgmq_create_partitioned(&qname, 2).unwrap();
+        let _ = pgmq_create_partitioned(&qname, 2, 2).unwrap();
 
         let queues = listit().unwrap();
         assert_eq!(queues.len(), 1);

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -39,6 +39,8 @@ fn pgmq_create(
     partition_interval: default!(String, "'daily'"),
     retention_interval: default!(String, "'5 days'"),
 ) -> Result<(), PgmqExtError> {
+    // TODO: data validation on partition_interval and retention_interval
+    // these need to both be parsed as integers, or both parsed as postgres durations
     let setup =
         partition::init_partitioned_queue(queue_name, &partition_interval, &retention_interval)?;
     let ran: Result<_, spi::Error> = Spi::connect(|mut c| {

--- a/pgmq/extension/src/partition.rs
+++ b/pgmq/extension/src/partition.rs
@@ -3,9 +3,9 @@ use pgmq_crate::{
     query::{check_input, create_archive, create_index, create_meta, insert_meta, TABLE_PREFIX},
 };
 
-// for now, put pg_partman in the public schema
+// for now, put pg_partman in the public PGMQ_SCHEMA
 const PARTMAN_SCHEMA: &str = "public";
-const SCHEMA: &str = "public";
+const PGMQ_SCHEMA: &str = "public";
 
 pub fn init_partitioned_queue(name: &str, partition_size: i64) -> Result<Vec<String>, PgmqError> {
     check_input(name)?;
@@ -17,14 +17,36 @@ pub fn init_partitioned_queue(name: &str, partition_size: i64) -> Result<Vec<Str
         create_archive(name)?,
         create_partman(name, partition_size)?,
         insert_meta(name)?,
+        set_retention_config(name)?,
     ])
+}
+
+// set retention policy for a queue
+// retention policy is only used for partition maintenance
+// messages .deleted() are immediately removed from the queue
+// messages .archived() will be retained forever on the `<queue_name>_archive` table
+// https://github.com/pgpartman/pg_partman/blob/ca212077f66af19c0ca317c206091cd31d3108b8/doc/pg_partman.md#retention
+// integer value will set that any partitions with an id value less than the current maximum id value minus the retention value will be dropped
+pub fn set_retention_config(queue: &str) -> Result<String, PgmqError> {
+    check_input(queue)?;
+    Ok(format!(
+        "
+        ALTER {PGMQ_SCHEMA}.part_config
+        SET 
+            retention = {queue},
+            retention_keep_table = false,
+            retention_keep_index = true,
+            automatic_maintenance = 'on'
+        WHERE parent_table = {PGMQ_SCHEMA}.{TABLE_PREFIX}_{queue}
+        "
+    ))
 }
 
 pub fn create_partitioned_queue(queue: &str) -> Result<String, PgmqError> {
     check_input(queue)?;
     Ok(format!(
         "
-        CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE_PREFIX}_{queue} (
+        CREATE TABLE IF NOT EXISTS {PGMQ_SCHEMA}.{TABLE_PREFIX}_{queue} (
             msg_id BIGSERIAL,
             read_ct INT DEFAULT 0,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT (now() at time zone 'utc'),
@@ -39,7 +61,7 @@ pub fn create_partitioned_index(queue: &str) -> Result<String, PgmqError> {
     check_input(queue)?;
     Ok(format!(
         "
-        CREATE INDEX IF NOT EXISTS msg_id_idx_{queue} ON {SCHEMA}.{TABLE_PREFIX}_{queue} (msg_id);
+        CREATE INDEX IF NOT EXISTS msg_id_idx_{queue} ON {PGMQ_SCHEMA}.{TABLE_PREFIX}_{queue} (msg_id);
         "
     ))
 }
@@ -48,7 +70,7 @@ pub fn create_partman(queue: &str, partition_size: i64) -> Result<String, PgmqEr
     check_input(queue)?;
     Ok(format!(
         "
-        SELECT {PARTMAN_SCHEMA}.create_parent('{SCHEMA}.{TABLE_PREFIX}_{queue}', 'msg_id', 'native', '{partition_size}');
+        SELECT {PARTMAN_SCHEMA}.create_parent('{PGMQ_SCHEMA}.{TABLE_PREFIX}_{queue}', 'msg_id', 'native', '{partition_size}');
         "
     ))
 }

--- a/pgmq/extension/tests/integration_tests.rs
+++ b/pgmq/extension/tests/integration_tests.rs
@@ -1,0 +1,75 @@
+use pgmq_crate::{conn_options, fetch_one_message};
+use rand::Rng;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{Pool, Postgres, Row};
+
+async fn connect(url: &str) -> Pool<Postgres> {
+    let options = conn_options(url).expect("failed to parse url");
+    PgPoolOptions::new()
+        .acquire_timeout(std::time::Duration::from_secs(10))
+        .max_connections(5)
+        .connect_with(options)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_lifecycle() {
+    let username = whoami::username();
+    let conn = connect(&format!("postgres://{username}:postgres@localhost:28815/pgmq")).await;
+    let mut rng = rand::thread_rng();
+    let test_num = rng.gen_range(0..100000);
+
+    // DROP EXTENSION
+    // requires pg_partman to already be installed in the instance
+    let _ = sqlx::query("DROP EXTENSION IF EXISTS pgmq")
+        .execute(&conn)
+        .await
+        .expect("failed to drop extension");
+
+    // CREATE EXTENSION
+    let _ = sqlx::query("CREATE EXTENSION pgmq cascade")
+        .execute(&conn)
+        .await
+        .expect("failed to create extension");
+
+    // CREATE with default retention and partition strategy
+    let _ = sqlx::query(&format!("SELECT pgmq_create('test_default_{test_num}');"))
+        .execute(&conn)
+        .await
+        .expect("failed to create queue");
+
+    let msg_id = sqlx::query(&format!(
+        "SELECT * from pgmq_send('test_default_{test_num}', '{{\"hello\": \"world\"}}');"
+    ))
+    .fetch_one(&conn)
+    .await
+    .expect("failed send")
+    .get::<i64, usize>(0);
+    assert_eq!(msg_id, 1);
+
+    // read message
+    let query = &format!("SELECT * from pgmq_read('test_default_{test_num}', 2, 1);");
+
+    let message = fetch_one_message::<serde_json::Value>(query, &conn)
+        .await
+        .expect("failed reading message")
+        .expect("expected message");
+    assert_eq!(message.msg_id, 1);
+
+    // CREATE with 5 seconds per partition, 10 seconds retention
+    let q = format!("SELECT \"pgmq_create\"('test_duration_{test_num}'::text, '5 seconds'::text, '10 seconds'::text);");
+    println!("q: {q}");
+    let _ = sqlx::query(&q)
+        .execute(&conn)
+        .await
+        .expect("failed creating duration queue");
+
+    // CREATE with 10 messages per partition, 20 messages retention
+    let _ = sqlx::query(&format!(
+        "SELECT \"pgmq_create\"('test_numeric_{test_num}'::text, '10'::text, '20'::text);"
+    ))
+    .execute(&conn)
+    .await
+    .expect("failed creating numeric interval queue");
+}


### PR DESCRIPTION
enables the retention policy on old partitions. pgmq will drop them according to the retention policy, which will by default be `5 days` with a new partition created each day.