### PR TITLE
[pgmq] remove redundant parsing

### DIFF
--- a/pgmq/extension/Cargo.lock
+++ b/pgmq/extension/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pgmq 0.11.1",
  "pgx",

--- a/pgmq/extension/Cargo.toml
+++ b/pgmq/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Postgres extension for PGMQ"

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -20,14 +20,6 @@ enum PgmqExtError {
     QueueError(#[from] PgmqError),
 }
 
-type MessageRow = (
-    i64,
-    i32,
-    TimestampWithTimeZone,
-    TimestampWithTimeZone,
-    pgx::JsonB,
-);
-
 #[pg_extern]
 fn pgmq_create_non_partitioned(queue_name: &str) -> Result<(), PgmqExtError> {
     let setup = init_queue(queue_name)?;

--- a/pgmq/extension/src/lib.rs
+++ b/pgmq/extension/src/lib.rs
@@ -1,4 +1,3 @@
-use pgx;
 use pgx::prelude::*;
 use pgx::spi;
 use pgx::spi::SpiTupleTable;
@@ -20,6 +19,14 @@ enum PgmqExtError {
     #[error("")]
     QueueError(#[from] PgmqError),
 }
+
+type MessageRow = (
+    i64,
+    i32,
+    TimestampWithTimeZone,
+    TimestampWithTimeZone,
+    pgx::JsonB,
+);
 
 #[pg_extern]
 fn pgmq_create_non_partitioned(queue_name: &str) -> Result<(), PgmqExtError> {
@@ -54,18 +61,19 @@ fn pgmq_create(
 
 #[pg_extern]
 fn pgmq_send(queue_name: &str, message: pgx::JsonB) -> Result<Option<i64>, PgmqExtError> {
-    let m = serde_json::to_string(&message.0).unwrap();
-    let query = enqueue_str(queue_name, &m)?;
-    Ok(Spi::get_one(&query)?)
+    let query = enqueue_str(queue_name)?;
+    Ok(Spi::get_one_with_args(
+        &query,
+        vec![(PgBuiltInOids::JSONBOID.oid(), message.into_datum())],
+    )?)
 }
 
-fn enqueue_str(name: &str, message: &str) -> Result<String, PgmqError> {
+fn enqueue_str(name: &str) -> Result<String, PgmqError> {
     check_input(name)?;
-    // TODO: vt should be now() + delay
     Ok(format!(
         "
         INSERT INTO {TABLE_PREFIX}_{name} (vt, message)
-        VALUES (now() at time zone 'utc', '{message}'::json)
+        VALUES (now() at time zone 'utc', $1)
         RETURNING msg_id;
         "
     ))


### PR DESCRIPTION
No need to serialize from json to string, then cast back to jsonb for the insert. Instead, leave it typed jsonb and insert it directly, bypassing the string parsing. Using a bind parameter for this, instead of using the `format!` macro, which would require us to cast the `pgx::jsonb` struct to string.