### PR TITLE
[COR-666] Improve logging and errors in trunk registry

### DIFF
--- a/trunk/trunk-registry/src/download.rs
+++ b/trunk/trunk-registry/src/download.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::errors::ExtensionRegistryError;
 use crate::uploader::extension_location;
 use actix_web::{get, web, HttpResponse, Responder};
+use log::info;
 use sqlx::{Pool, Postgres};
 
 /// Handles the `GET /extensions/:extension_name/:version/download` route.
@@ -13,6 +14,8 @@ pub async fn download(cfg: web::Data<Config>, path: web::Path<(String, String)>)
     // TODO(ianstanton) Increment download count for extension
     // TODO(ianstanton) Use latest version if none provided
     let url = extension_location(&cfg.bucket_name, &name, &version);
+    info!("Download requested for {} version {}", name, version);
+    info!("URL: {}", url);
     HttpResponse::Ok().body(url)
 }
 

--- a/trunk/trunk-registry/src/errors.rs
+++ b/trunk/trunk-registry/src/errors.rs
@@ -12,11 +12,11 @@ impl error::ResponseError for ExtensionRegistryError {}
 #[derive(Error, Debug)]
 pub enum ExtensionRegistryError {
     /// a url parsing error
-    #[error("url parsing error {0}")]
+    #[error("url parsing error: {0}")]
     UrlParsingError(#[from] ParseError),
 
     /// a database error
-    #[error("database error {0}")]
+    #[error("database error: {0}")]
     DatabaseError(#[from] sqlx::Error),
 
     /// a response error
@@ -25,33 +25,33 @@ pub enum ExtensionRegistryError {
 
     /// an authorization error
     #[error("authorization error")]
-    AuthorizationError(),
+    AuthorizationError,
 
     /// a payload error
-    #[error("payload error")]
+    #[error("payload error: {0}")]
     PayloadError(#[from] error::PayloadError),
 
     /// a bad request error
-    #[error("bad request error")]
+    #[error("bad request error: {0}")]
     ErrorBadRequest(#[from] error::Error),
 
     /// a serde json error
-    #[error("serde json error")]
+    #[error("serde json error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
 
     /// a multipart error
-    #[error("multipart error")]
+    #[error("multipart error: {0}")]
     MultipartError(#[from] MultipartError),
 
     /// a reqwest error
-    #[error("reqwest error")]
+    #[error("reqwest error: {0}")]
     ReqwestError(#[from] reqwest::Error),
 
     /// a std io error
-    #[error("std io error")]
+    #[error("std io error: {0}")]
     StdIoError(#[from] std::io::Error),
 
     /// a put object error
-    #[error("put object error")]
+    #[error("put object error: {0}")]
     PutObjectError(#[from] SdkError<PutObjectError>),
 }

--- a/trunk/trunk-registry/src/errors.rs
+++ b/trunk/trunk-registry/src/errors.rs
@@ -25,7 +25,7 @@ pub enum ExtensionRegistryError {
 
     /// an authorization error
     #[error("authorization error")]
-    AuthorizationError,
+    AuthorizationError(),
 
     /// a payload error
     #[error("payload error: {0}")]

--- a/trunk/trunk-registry/src/publish.rs
+++ b/trunk/trunk-registry/src/publish.rs
@@ -36,7 +36,7 @@ pub async fn publish(
         let auth = headers.get(AUTHORIZATION).unwrap();
         if auth != cfg.auth_token {
             error!("Authorization error");
-            return Err(AuthorizationError);
+            return Err(AuthorizationError());
         }
         // Field is stream of Bytes
         while let Some(chunk) = field.try_next().await? {

--- a/trunk/trunk-registry/src/publish.rs
+++ b/trunk/trunk-registry/src/publish.rs
@@ -12,6 +12,7 @@ use aws_config::SdkConfig;
 use aws_sdk_s3;
 use aws_sdk_s3::primitives::ByteStream;
 use futures::TryStreamExt;
+use log::error;
 use sqlx::{Pool, Postgres};
 
 const MAX_SIZE: usize = 262_144; // max payload size is 256k
@@ -34,7 +35,8 @@ pub async fn publish(
         let headers = field.headers();
         let auth = headers.get(AUTHORIZATION).unwrap();
         if auth != cfg.auth_token {
-            return Err(AuthorizationError());
+            error!("Authorization error");
+            return Err(AuthorizationError);
         }
         // Field is stream of Bytes
         while let Some(chunk) = field.try_next().await? {

--- a/trunk/trunk-registry/src/uploader.rs
+++ b/trunk/trunk-registry/src/uploader.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::ServerSideEncryption::Aes256;
-use log::debug;
+use log::{debug, info};
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
@@ -54,7 +54,7 @@ pub async fn upload_extension(
     vers: &semver::Version,
 ) -> Result<String, ExtensionRegistryError> {
     let path = extension_path(&extension.name, &vers.to_string());
-    println!("Uploading");
+    info!("Uploading extension: {:?}", extension);
     upload(bucket_name, s3_client, &path, file, "application/gzip").await?;
     Ok("Successfully uploaded extension".to_owned())
 }

--- a/trunk/trunk-registry/src/views/extension_publish.rs
+++ b/trunk/trunk-registry/src/views/extension_publish.rs
@@ -1,7 +1,7 @@
 //! This module handles the expected information an extension should have
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ExtensionUpload {
     pub name: String,
     pub vers: semver::Version,


### PR DESCRIPTION
Improves logging in trunk registry and error responses to CLI. Example logs:
```
[2023-04-26T19:11:59Z INFO  aws_config::meta::region] load_region; provider=EnvironmentVariableRegionProvider { env: Env(Real) }
[2023-04-26T19:11:59Z INFO  aws_config::meta::region] load_region; provider=ProfileFileRegionProvider { provider_config: ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(TokioSleep), region: None } }
[2023-04-26T19:11:59Z INFO  aws_config::meta::region] load_region; provider=ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(TokioSleep), region: None }) } }, env: Env(Real) }
[2023-04-26T19:12:00Z WARN  aws_config::imds::region] failed to load region from IMDS err=failed to load IMDS session token: dispatch failure: timeout: error trying to connect: HTTP connect timeout occurred after 1s: HTTP connect timeout occurred after 1s: timed out (FailedToLoadToken(FailedToLoadToken { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: hyper::Error(Connect, HttpTimeoutError { kind: "HTTP connect", duration: 1s }), connection: Unknown } }) }))
[2023-04-26T19:12:00Z INFO  aws_config::meta::region] load_region; provider=EnvironmentVariableRegionProvider { env: Env(Real) }
[2023-04-26T19:12:00Z INFO  aws_config::meta::region] load_region; provider=ProfileFileRegionProvider { provider_config: ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(TokioSleep), region: None } }
[2023-04-26T19:12:00Z INFO  aws_config::meta::region] load_region; provider=ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(TokioSleep), region: None }) } }, env: Env(Real) }
[2023-04-26T19:12:01Z WARN  aws_config::imds::region] failed to load region from IMDS err=failed to load IMDS session token: dispatch failure: timeout: error trying to connect: HTTP connect timeout occurred after 1s: HTTP connect timeout occurred after 1s: timed out (FailedToLoadToken(FailedToLoadToken { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: hyper::Error(Connect, HttpTimeoutError { kind: "HTTP connect", duration: 1s }), connection: Unknown } }) }))
[2023-04-26T19:12:01Z INFO  sqlx::postgres::notice] relation "_sqlx_migrations" already exists, skipping
[2023-04-26T19:12:01Z INFO  actix_server::builder] starting 16 workers
[2023-04-26T19:12:01Z INFO  actix_server::server] Actix runtime found; starting in Actix runtime
[2023-04-26T19:13:51Z ERROR trunk_registry::publish] Authorization error
[2023-04-26T19:14:01Z INFO  trunk_registry::uploader] Uploading extension: ExtensionUpload { name: "bloom", vers: Version { major: 1, minor: 0, patch: 0 }, description: Some("bloom provides an index access method based on Bloom filters."), homepage: Some("https://www.postgresql.org"), documentation: Some("https://www.postgresql.org/docs/current/bloom.html"), license: Some("PostgreSQL"), repository: Some("https://github.com/postgres/postgres") }

```