### PR TITLE
[coredb-operator]: Create Cluster RBAC objects for all databases

### DIFF
--- a/coredb-operator/.gitignore
+++ b/coredb-operator/.gitignore
@@ -2,3 +2,4 @@
 
 # VSCode
 .vscode
+./.vscode

--- a/coredb-operator/Cargo.lock
+++ b/coredb-operator/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.1"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -323,16 +323,15 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -503,7 +502,7 @@ dependencies = [
  "serde_yaml 0.9.19",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower-test",
  "tracing",
  "tracing-opentelemetry",
@@ -750,13 +749,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -771,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -961,9 +960,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1135,13 +1134,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1155,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -1365,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "local-channel"
@@ -1569,7 +1568,7 @@ dependencies = [
  "prost",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -1582,7 +1581,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "prost",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
 ]
 
@@ -1657,7 +1656,7 @@ checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -1694,9 +1693,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1748,9 +1747,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.21"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.104",
@@ -1798,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
 dependencies = [
  "bytes",
  "heck",
@@ -1927,13 +1926,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -1974,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
  "bitflags",
  "errno",
@@ -2231,15 +2239,15 @@ checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2470,10 +2478,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.8.3"
+name = "tonic"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fa2c5e870bdce133847d15e075333e6e1ca3fff913001fede6754f3060e367"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2517,7 +2553,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2881,13 +2916,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2896,7 +2931,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2905,13 +2949,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2921,10 +2980,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2933,10 +3004,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2945,16 +3028,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yaml-rust"

--- a/coredb-operator/Cargo.toml
+++ b/coredb-operator/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 tracing-opentelemetry = "0.18.0"
 opentelemetry = { version = "0.18.0", features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.11.0", features = ["tokio"], optional = true }
-tonic = { version = "0.8.3", optional = true }
+tonic = { version = "0.9.0", optional = true }
 thiserror = "1.0.39"
 passwords = "3.1.12"
 regex = "1.7.1"

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -58,7 +58,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/coredb/coredb-pg-slim:4116deb
+                default: quay.io/coredb/coredb-pg-slim:2d3350f
                 type: string
               pkglibdirStorage:
                 default: 1Gi
@@ -192,6 +192,150 @@ spec:
                         This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
                       type: string
                     description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              serviceAccountTemplate:
+                default:
+                  metadata: null
+                properties:
+                  metadata:
+                    description: ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: |-
+                          Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.
+
+                          The name in the go struct is changed to help clients detect accidental use.
+                        type: string
+                      creationTimestamp:
+                        description: |-
+                          CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                          Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        format: date-time
+                        type: string
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        description: |-
+                          DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                          Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        format: date-time
+                        type: string
+                      finalizers:
+                        description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                          If this field is specified and the generated name exists, the server will return a 409.
+
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      managedFields:
+                        description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                        items:
+                          description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+                          properties:
+                            apiVersion:
+                              description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                              type: string
+                            fieldsType:
+                              description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                              type: string
+                            fieldsV1:
+                              description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                              type: object
+                            manager:
+                              description: Manager is an identifier of the workflow managing these fields.
+                              type: string
+                            operation:
+                              description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                              type: string
+                            subresource:
+                              description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                              type: string
+                            time:
+                              description: Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+                              format: date-time
+                              type: string
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
                     type: object
                 type: object
               sharedirStorage:

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -58,7 +58,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/coredb/coredb-pg-slim:2d3350f
+                default: quay.io/coredb/coredb-pg-slim:b5c86b2
                 type: string
               pkglibdirStorage:
                 default: 1Gi

--- a/coredb-operator/src/apis/coredb_types.rs
+++ b/coredb-operator/src/apis/coredb_types.rs
@@ -1,11 +1,19 @@
 use crate::extensions::Extension;
-use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::resource::Quantity};
+use k8s_openapi::{
+    api::core::v1::ResourceRequirements,
+    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
+};
 
 use crate::defaults;
 use kube::CustomResource;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+pub struct ServiceAccountTemplate {
+    pub metadata: Option<ObjectMeta>,
+}
 
 /// Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
 ///
@@ -40,6 +48,8 @@ pub struct CoreDBSpec {
     pub extensions: Vec<Extension>,
     #[serde(default = "defaults::default_stop")]
     pub stop: bool,
+    #[serde(default = "defaults::default_service_account_template")]
+    pub serviceAccountTemplate: ServiceAccountTemplate,
 }
 
 /// The status object of `CoreDB`

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -8,6 +8,7 @@ use futures::{
 use crate::{
     exec::{ExecCommand, ExecOutput},
     psql::{PsqlCommand, PsqlOutput},
+    rbac::reconcile_rbac,
     service::reconcile_svc,
     statefulset::{reconcile_sts, stateful_set_from_cdb},
 };
@@ -86,6 +87,12 @@ impl CoreDB {
         let ns = self.namespace().unwrap();
         let name = self.name_any();
         let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &ns);
+
+        // reconcile service account, role, and role binding
+        reconcile_rbac(self, ctx.clone()).await.map_err(|e| {
+            error!("Error reconciling service account: {:?}", e);
+            Action::requeue(Duration::from_secs(10))
+        })?;
 
         // reconcile secret
         reconcile_secret(self, ctx.clone()).await.map_err(|e| {

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -91,7 +91,7 @@ impl CoreDB {
         // reconcile service account, role, and role binding
         reconcile_rbac(self, ctx.clone()).await.map_err(|e| {
             error!("Error reconciling service account: {:?}", e);
-            Action::requeue(Duration::from_secs(10))
+            Action::requeue(Duration::from_secs(300))
         })?;
 
         // reconcile secret

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -35,7 +35,7 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/coredb/coredb-pg-slim:2d3350f".to_owned()
+    "quay.io/coredb/coredb-pg-slim:b5c86b2".to_owned()
 }
 
 pub fn default_storage() -> Quantity {

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -1,7 +1,7 @@
 use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::resource::Quantity};
 use std::collections::BTreeMap;
 
-use crate::extensions::Extension;
+use crate::{apis::coredb_types::ServiceAccountTemplate, extensions::Extension};
 
 pub fn default_replicas() -> i32 {
     1
@@ -35,23 +35,20 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/coredb/coredb-pg-slim:4116deb".to_owned()
+    "quay.io/coredb/coredb-pg-slim:2d3350f".to_owned()
 }
 
 pub fn default_storage() -> Quantity {
     Quantity("8Gi".to_string())
 }
 
-
 pub fn default_sharedir_storage() -> Quantity {
     Quantity("1Gi".to_string())
 }
 
-
 pub fn default_pkglibdir_storage() -> Quantity {
     Quantity("1Gi".to_string())
 }
-
 
 pub fn default_postgres_exporter_image() -> String {
     "quay.io/prometheuscommunity/postgres-exporter:v0.11.1".to_owned()
@@ -79,4 +76,8 @@ pub fn default_stop() -> bool {
 
 pub fn default_extensions_updating() -> bool {
     false
+}
+
+pub fn default_service_account_template() -> ServiceAccountTemplate {
+    ServiceAccountTemplate { metadata: None }
 }

--- a/coredb-operator/src/exec.rs
+++ b/coredb-operator/src/exec.rs
@@ -58,7 +58,6 @@ impl ExecCommand {
         let mut result_stderr = String::new();
         stderr_reader.read_to_string(&mut result_stderr).await.unwrap();
 
-
         let status = attached_process.take_status().unwrap().await.unwrap();
         // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         let response = ExecOutput::new(Some(result_stdout), Some(result_stderr), Some(status.clone()));

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -176,7 +176,6 @@ pub async fn install_extension(
     Ok(())
 }
 
-
 /// handles create/drop extensions
 pub async fn toggle_extensions(
     cdb: &CoreDB,
@@ -452,7 +451,6 @@ pub async fn reconcile_extensions(
     // return final state of extensions
     get_all_extensions(coredb, ctx.clone()).await
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/coredb-operator/src/extensions.rs
+++ b/coredb-operator/src/extensions.rs
@@ -220,7 +220,7 @@ pub async fn toggle_extensions(
                     }
                     false => {
                         info!("Dropping extension: {}, database {}", ext_name, database_name);
-                        format!("DROP EXTENSION IF EXISTS \"{ext_name}\";")
+                        format!("DROP EXTENSION IF EXISTS \"{ext_name}\" CASCADE;")
                     }
                 };
 

--- a/coredb-operator/src/lib.rs
+++ b/coredb-operator/src/lib.rs
@@ -15,6 +15,7 @@ mod extensions;
 #[cfg(test)] pub mod fixtures;
 mod postgres_exporter_role;
 mod psql;
+mod rbac;
 mod secret;
 mod service;
 mod statefulset;

--- a/coredb-operator/src/rbac.rs
+++ b/coredb-operator/src/rbac.rs
@@ -1,0 +1,190 @@
+use crate::{apis::coredb_types::CoreDB, Context, Error};
+use k8s_openapi::{
+    api::{
+        core::v1::ServiceAccount,
+        rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject},
+    },
+    apimachinery::pkg::apis::meta::v1::ObjectMeta,
+};
+use kube::{
+    api::{Patch, PatchParams},
+    Api, ResourceExt,
+};
+use std::{collections::BTreeMap, sync::Arc, vec};
+//use tracing::debug;
+
+// reconcile kubernetes rbac resources
+pub async fn reconcile_rbac(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Error> {
+    // reconcile service account
+    let sa = reconcile_service_account(cdb, ctx.clone()).await?;
+    // reconcile role
+    let role = reconcile_role(cdb, ctx.clone()).await?;
+    // reconcile role binding
+    reconcile_role_binding(cdb, ctx.clone(), sa, role).await?;
+
+    Ok(())
+}
+
+// reconcile a kubernetes service account
+async fn reconcile_service_account(cdb: &CoreDB, ctx: Arc<Context>) -> Result<ServiceAccount, Error> {
+    let client = ctx.client.clone();
+    let ns = cdb.namespace().unwrap();
+    let name = format!("{}-sa", cdb.name_any());
+    let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), &ns);
+
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    labels.insert("app".to_owned(), "coredb".to_string());
+    labels.insert("coredb.io/name".to_owned(), cdb.name_any());
+
+    let mut sa_metadata = ObjectMeta {
+        name: Some(name.to_owned()),
+        namespace: Some(ns.to_owned()),
+        labels: Some(labels.clone()),
+        ..ObjectMeta::default()
+    };
+
+    if let Some(ref template_metadata) = cdb.spec.serviceAccountTemplate.metadata {
+        if let Some(ref annotations) = template_metadata.annotations {
+            sa_metadata.annotations = Some(annotations.clone());
+        }
+    }
+
+    let sa = ServiceAccount {
+        metadata: sa_metadata,
+        ..ServiceAccount::default()
+    };
+
+    let ps = PatchParams::apply("cntrlr").force();
+    let _o = sa_api
+        .patch(&name, &ps, &Patch::Apply(&sa))
+        .await
+        .map_err(Error::KubeError)?;
+
+    Ok(sa)
+}
+
+async fn reconcile_role(cdb: &CoreDB, ctx: Arc<Context>) -> Result<Role, Error> {
+    let client = ctx.client.clone();
+    let ns = cdb.namespace().unwrap();
+    let name = format!("{}-role", cdb.name_any());
+    let role_api: Api<Role> = Api::namespaced(client.clone(), &ns);
+
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    labels.insert("app".to_owned(), "coredb".to_string());
+    labels.insert("coredb.io/name".to_owned(), cdb.name_any());
+
+    let rules = create_policy_rules(cdb);
+
+    let role = Role {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            namespace: Some(ns.to_owned()),
+            labels: Some(labels.clone()),
+            ..ObjectMeta::default()
+        },
+        rules: Some(rules.await),
+    };
+
+    let ps = PatchParams::apply("cntrlr").force();
+    let _o = role_api
+        .patch(&name, &ps, &Patch::Apply(&role))
+        .await
+        .map_err(Error::KubeError)?;
+
+    Ok(role)
+}
+
+async fn reconcile_role_binding(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+    sa: ServiceAccount,
+    role: Role,
+) -> Result<(), Error> {
+    let client = ctx.client.clone();
+    let ns = cdb.namespace().unwrap();
+    let name = format!("{}-role-binding", cdb.name_any());
+    let role_binding_api: Api<RoleBinding> = Api::namespaced(client.clone(), &ns);
+    let sa_name = sa.name_any();
+    let role_name = role.name_any();
+
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    labels.insert("app".to_owned(), "coredb".to_string());
+    labels.insert("coredb.io/name".to_owned(), cdb.name_any());
+
+    let role_ref = RoleRef {
+        api_group: "rbac.authorization.k8s.io".to_string(),
+        kind: "Role".to_string(),
+        name: role_name.to_string(),
+    };
+
+    let subject = Subject {
+        kind: "ServiceAccount".to_string(),
+        name: sa_name.to_string(),
+        namespace: Some(ns.to_owned()),
+        ..Subject::default()
+    };
+
+    let metadata = ObjectMeta {
+        name: Some(name.to_owned()),
+        namespace: Some(ns.to_owned()),
+        labels: Some(labels.clone()),
+        ..ObjectMeta::default()
+    };
+
+    let rb = RoleBinding {
+        metadata,
+        role_ref,
+        subjects: Some(vec![subject]),
+    };
+
+    let ps = PatchParams::apply("cntrlr").force();
+    let _o = role_binding_api
+        .patch(&name, &ps, &Patch::Apply(&rb))
+        .await
+        .map_err(Error::KubeError)?;
+
+    Ok(())
+}
+
+// Create role policy rulesets
+async fn create_policy_rules(cdb: &CoreDB) -> Vec<PolicyRule> {
+    vec![
+        // This policy allows get, list, watch access to the coredb resource
+        PolicyRule {
+            api_groups: Some(vec!["coredbs.coredb.io".to_owned()]),
+            resource_names: Some(vec![cdb.name_any()]),
+            resources: Some(vec!["coredb".to_owned()]),
+            verbs: vec!["get".to_string(), "list".to_string(), "watch".to_string()],
+            ..PolicyRule::default()
+        },
+        // This policy allows get, patch, update, watch access to the coredb/status resource
+        PolicyRule {
+            api_groups: Some(vec!["coredbs.coredb.io".to_owned()]),
+            resource_names: Some(vec![cdb.name_any()]),
+            resources: Some(vec!["coredb/status".to_owned()]),
+            verbs: vec![
+                "get".to_string(),
+                "patch".to_string(),
+                "update".to_string(),
+                "watch".to_string(),
+            ],
+            ..PolicyRule::default()
+        },
+        // This policy allows get, watch access to a secret in the namespace
+        PolicyRule {
+            api_groups: Some(vec!["".to_owned()]),
+            resource_names: Some(vec![format!("{}-connection", cdb.name_any())]),
+            resources: Some(vec!["secrets".to_owned()]),
+            verbs: vec!["get".to_string(), "watch".to_string()],
+            ..PolicyRule::default()
+        },
+        // This policy for now is specifically open for all configmaps in the namespace
+        // We currently do not have any configmaps
+        PolicyRule {
+            api_groups: Some(vec!["".to_owned()]),
+            resources: Some(vec!["configmaps".to_owned()]),
+            verbs: vec!["get".to_string(), "watch".to_string()],
+            ..PolicyRule::default()
+        },
+    ]
+}

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -31,7 +31,6 @@ const PKGLIBDIR: &str = "/usr/lib/postgresql/15/lib";
 const SHAREDIR: &str = "/usr/share/postgresql/15";
 const DATADIR: &str = "/var/lib/postgresql/data";
 
-
 pub fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
     let ns = cdb.namespace().unwrap();
     let name = cdb.name_any();
@@ -176,6 +175,7 @@ pub fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
             },
             template: PodTemplateSpec {
                 spec: Some(PodSpec {
+                    service_account_name: Some(format!("{}-sa", cdb.name_any())),
                     containers,
                     init_containers: Option::from(vec![Container {
                         env: postgres_env,

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -18,12 +18,14 @@ mod test {
         is_pod_ready,
     };
     use k8s_openapi::{
-        api::apps::v1::StatefulSet,
-        api::core::v1::{
-            Container, Namespace, PersistentVolumeClaim, Pod, PodSpec, ResourceRequirements, Secret,
-            ServiceAccount,
+        api::{
+            apps::v1::StatefulSet,
+            core::v1::{
+                Container, Namespace, PersistentVolumeClaim, Pod, PodSpec, ResourceRequirements, Secret,
+                ServiceAccount,
+            },
+            rbac::v1::{Role, RoleBinding},
         },
-        api::rbac::v1::{Role, RoleBinding},
         apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
         apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
     };
@@ -33,8 +35,7 @@ mod test {
         Api, Client, Config,
     };
     use rand::Rng;
-    use std::collections::BTreeMap;
-    use std::{str, thread, time::Duration};
+    use std::{collections::BTreeMap, str, thread, time::Duration};
     use tokio::io::AsyncReadExt;
 
     const API_VERSION: &str = "coredb.io/v1alpha1";

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -11,24 +11,29 @@
 
 #[cfg(test)]
 mod test {
+    use chrono::{DateTime, SecondsFormat, Utc};
     use controller::{
         apis::coredb_types::CoreDB,
         defaults::{default_resources, default_storage},
         is_pod_ready,
     };
     use k8s_openapi::{
+        api::apps::v1::StatefulSet,
         api::core::v1::{
             Container, Namespace, PersistentVolumeClaim, Pod, PodSpec, ResourceRequirements, Secret,
+            ServiceAccount,
         },
+        api::rbac::v1::{Role, RoleBinding},
         apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
         apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
     };
     use kube::{
-        api::{AttachParams, Patch, PatchParams, PostParams},
+        api::{AttachParams, ListParams, Patch, PatchParams, PostParams},
         runtime::wait::{await_condition, conditions, Condition},
         Api, Client, Config,
     };
     use rand::Rng;
+    use std::collections::BTreeMap;
     use std::{str, thread, time::Duration};
     use tokio::io::AsyncReadExt;
 
@@ -119,13 +124,6 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
-                "serviceAccountTemplate": {
-                    "metadata": {
-                        "annotations": {
-                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
-                        }
-                    }
-                },
                 "extensions": [
                     {
                         "name": "postgis",
@@ -292,13 +290,7 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
-                "serviceAccountTemplate": {
-                    "metadata": {
-                        "annotations": {
-                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
-                        }
-                    }
-                },
+
                 "extensions": [
                     {
                         "name": "postgis",
@@ -355,13 +347,6 @@ mod test {
             "spec": {
                 "pkglibdirStorage": "2Gi",
                 "sharedirStorage" : "2Gi",
-                "serviceAccountTemplate": {
-                    "metadata": {
-                        "annotations": {
-                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
-                        }
-                    }
-                }
             }
         });
         let params = PatchParams::apply("coredb-integration-test");
@@ -374,6 +359,156 @@ mod test {
         let storage = pvc.spec.unwrap().resources.unwrap().requests.unwrap();
         let s = storage.get("storage").unwrap().to_owned();
         assert_eq!(Quantity("2Gi".to_owned()), s);
+
+        // Update the coredb resource to add rbac
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "serviceAccountTemplate": {
+                    "metadata": {
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
+                        }
+                    }
+                }
+            }
+        });
+
+        // apply CRD with serviceAccountTemplate set
+        let params = PatchParams::apply("coredb-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let _coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // give it some time 500ms
+        thread::sleep(Duration::from_millis(5000));
+
+        // Assert that the service account exists
+        let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+        let sa_name = format!("{}-sa", name);
+        let sa = sa_api.get(&sa_name).await.unwrap();
+
+        // Check if the service account is set correctly
+        assert_eq!(sa.metadata.name.unwrap(), sa_name);
+
+        // Check if the annotation is set correctly
+        assert_eq!(
+            sa.metadata.annotations.unwrap().get("eks.amazonaws.com/role-arn"),
+            Some(&"arn:aws:iam::012345678901:role/cdb-test-iam".to_string())
+        );
+
+        // Assert that the role exists
+        let role_api: Api<Role> = Api::namespaced(client.clone(), namespace);
+        let role_name = format!("{}-role", name);
+        let role = role_api.get(&role_name).await.unwrap();
+        assert_eq!(role.metadata.name.unwrap(), role_name);
+
+        // Assert that the role binding exists
+        let rb_api: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+        let rb_name = format!("{}-role-binding", name);
+        let role_binding = rb_api.get(&rb_name).await.unwrap();
+        assert_eq!(role_binding.metadata.name.unwrap(), rb_name);
+
+        // Get the StatefulSet
+        let stateful_sets_api: Api<StatefulSet> = Api::namespaced(client.clone(), namespace);
+        let stateful_set_name = format!("{}", name);
+        let stateful_set = stateful_sets_api.get(&stateful_set_name).await.unwrap();
+
+        //println!("stateful_set: {:#?}", stateful_set_name);
+
+        // Assert that the StatefulSet has the correct service account
+        let stateful_set_service_account_name = stateful_set
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .spec
+            .as_ref()
+            .unwrap()
+            .service_account_name
+            .as_ref();
+        assert_eq!(stateful_set_service_account_name, Some(&sa_name));
+
+        // Restart the StatefulSet to apply updates to the running pod
+        let mut stateful_set_updated = stateful_set.clone();
+        stateful_set_updated
+            .spec
+            .as_mut()
+            .unwrap()
+            .template
+            .metadata
+            .as_mut()
+            .unwrap()
+            .annotations
+            .get_or_insert_with(BTreeMap::new)
+            .insert(
+                "kubectl.kubernetes.io/restartedAt".to_string(),
+                Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            );
+
+        let params = PatchParams::default();
+        let patch = Patch::Merge(&stateful_set_updated);
+        let _stateful_set_patched = stateful_sets_api
+            .patch(&stateful_set_name, &params, &patch)
+            .await
+            .unwrap();
+
+        // Wait for the pod to restart
+        let pods_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
+        let lp = ListParams::default().labels(format!("statefulset={}", stateful_set_name).as_str());
+
+        //let restart_time = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        let restart_time = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true).to_string();
+
+        loop {
+            let pods = pods_api.list(&lp).await.unwrap();
+
+            let all_pods_ready_and_restarted = pods.iter().all(|pod| {
+                let pod_restart_time = pod
+                    .metadata
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.get("kubectl.kubernetes.io/restartedAt"))
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&Utc)) // Convert to DateTime<Utc>
+                    .unwrap_or_else(|| Utc::now());
+                let restart_time_as_datetime = DateTime::parse_from_rfc3339(&restart_time)
+                    .unwrap()
+                    .with_timezone(&Utc);
+                pod_restart_time > restart_time_as_datetime
+                    && pod
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.container_statuses.as_ref())
+                        .map(|container_statuses| container_statuses.iter().all(|cs| cs.ready))
+                        .unwrap_or(false)
+            });
+
+            if all_pods_ready_and_restarted {
+                break;
+            }
+
+            thread::sleep(Duration::from_secs(15));
+        }
+
+        // Check the pods service account
+        //let all_pods = pods_api.list(&ListParams::default()).await.unwrap();
+        //println!("All pods in the namespace: {:?}", all_pods);
+
+        let pods = pods_api.list(&lp).await.unwrap();
+        let pod = match pods.iter().next() {
+            Some(pod) => pod,
+            None => {
+                println!("Expected label: {}", format!("statefulset={}", stateful_set_name));
+                panic!("No matching pods found")
+            }
+        };
+
+        let pod_service_account_name = pod.spec.as_ref().unwrap().service_account_name.as_ref();
+        assert_eq!(pod_service_account_name, Some(&sa_name));
     }
 
     #[tokio::test]
@@ -411,13 +546,6 @@ mod test {
             },
             "spec": {
                 "replicas": 1,
-                "serviceAccountTemplate": {
-                    "metadata": {
-                        "annotations": {
-                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
-                        }
-                    }
-                },
                 "extensions": [
                     {
                         "name": "postgis",

--- a/coredb-operator/tests/integration_tests.rs
+++ b/coredb-operator/tests/integration_tests.rs
@@ -119,6 +119,13 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
+                "serviceAccountTemplate": {
+                    "metadata": {
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
+                        }
+                    }
+                },
                 "extensions": [
                     {
                         "name": "postgis",
@@ -285,6 +292,13 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
+                "serviceAccountTemplate": {
+                    "metadata": {
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
+                        }
+                    }
+                },
                 "extensions": [
                     {
                         "name": "postgis",
@@ -340,8 +354,14 @@ mod test {
             },
             "spec": {
                 "pkglibdirStorage": "2Gi",
-                "sharedirStorage" : "2Gi"
-
+                "sharedirStorage" : "2Gi",
+                "serviceAccountTemplate": {
+                    "metadata": {
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
+                        }
+                    }
+                }
             }
         });
         let params = PatchParams::apply("coredb-integration-test");
@@ -391,6 +411,13 @@ mod test {
             },
             "spec": {
                 "replicas": 1,
+                "serviceAccountTemplate": {
+                    "metadata": {
+                        "annotations": {
+                            "eks.amazonaws.com/role-arn": "arn:aws:iam::012345678901:role/cdb-test-iam"
+                        }
+                    }
+                },
                 "extensions": [
                     {
                         "name": "postgis",


### PR DESCRIPTION
#### What this PR does / why we need it

For backups we need to be able to set an AWS IAM role for the Kubernetes ServiceAccount.  We currently are not managing the `ServiceAccount`, `Role` and `RoleBinding` needed to make this work correctly.

#### Which issue this PR fixes

- fixes # [COR-722](https://linear.app/coredb/issue/COR-722/create-serviceaccount-for-coredb-cr-instance)