### PR TITLE
[postgres image]: Adding extensions back to the image

### DIFF
--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.6"
+version = "15.2.0-coredb-pg-slim.7"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -69,16 +69,18 @@ RUN apt-get update && apt-get install -y \
 
 COPY ./postgresql.conf /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample
 
-  WORKDIR /git
-  RUN git clone --branch "v${PG_VECTOR_VER}" https://github.com/pgvector/pgvector.git
-  WORKDIR /git/pgvector
-  RUN set -xe; \
-        make; \
-        make install;
+WORKDIR /git
+RUN git clone --branch "v${PG_VECTOR_VER}" https://github.com/pgvector/pgvector.git
+WORKDIR /git/pgvector
+RUN set -xe; \
+      make; \
+      make install;
+
+WORKDIR / 
+RUN rm -rf /git
   
-  WORKDIR / 
-  RUN rm -rf /git
-  
+RUN trunk install --version ${PG_PARTMAN_VER} pg_partman && trunk install --version ${PGMQ_VER} pgmq
+
 # cache extensions and shared libraries
 RUN mkdir /tmp/pg_sharedir && \
         mkdir /tmp/pg_pkglibdir && \

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -79,7 +79,7 @@ RUN set -xe; \
 WORKDIR / 
 RUN rm -rf /git
   
-RUN trunk install --version ${PG_PARTMAN_VER} pg_partman && trunk install --version ${PGMQ_VER} pgmq
+RUN trunk install --version ${PG_PARTMAN_VER} pg_partman
 
 # cache extensions and shared libraries
 RUN mkdir /tmp/pg_sharedir && \

--- a/postgres/coredb-pg-slim/postgresql.conf
+++ b/postgres/coredb-pg-slim/postgresql.conf
@@ -831,6 +831,3 @@ dynamic_shared_memory_type = 'posix'
 full_page_writes = 'on'
 hot_standby = 'true'
 shared_preload_libraries = 'pg_stat_statements,pg_cron,pgaudit,pg_partman_bgw'
-pg_partman_bgw.dbname = 'postgres'
-pg_partman_bgw.interval = 15
-pg_partman_bgw.role = 'postgres'

--- a/postgres/coredb-pg-slim/postgresql.conf
+++ b/postgres/coredb-pg-slim/postgresql.conf
@@ -831,3 +831,6 @@ dynamic_shared_memory_type = 'posix'
 full_page_writes = 'on'
 hot_standby = 'true'
 shared_preload_libraries = 'pg_stat_statements,pg_cron,pgaudit,pg_partman_bgw'
+pg_partman_bgw.dbname = 'postgres'
+pg_partman_bgw.interval = 15
+pg_partman_bgw.role = 'postgres'


### PR DESCRIPTION
#### What this PR does / why we need it

Since pg_partman is now installable via trunk and we removed it from the base image, we also need to remove the configuration for it.

#### Which issue this PR fixes

- fixes #