### PR TITLE
make sure the wal-g binary is executable

### DIFF
--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.7"
+version = "15.2.0-coredb-pg-slim.8"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -8,7 +8,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN /root/.cargo/bin/cargo install --version $TRUNK_VER pg-trunk
 
 # Grab wal-g binary
-RUN curl -L -o /tmp/wal-g "https://github.com/wal-g/wal-g/releases/download/v$WALG_VER/wal-g-pg-ubuntu-20.04-amd64"
+RUN curl -L -o /tmp/wal-g "https://github.com/wal-g/wal-g/releases/download/v$WALG_VER/wal-g-pg-ubuntu-20.04-amd64" \
+    && chmod +x /tmp/wal-g
 
 FROM quay.io/coredb/ubuntu:22.04
 


### PR DESCRIPTION
Ensure that the `wal-g` binary is executable on the file system 