### PR TITLE
update base slim image to 0a1db4

### DIFF
--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -58,7 +58,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/coredb/coredb-pg-slim:b5c86b2
+                default: quay.io/coredb/coredb-pg-slim:0a1db4d
                 type: string
               pkglibdirStorage:
                 default: 1Gi

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -35,7 +35,7 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/coredb/coredb-pg-slim:b5c86b2".to_owned()
+    "quay.io/coredb/coredb-pg-slim:0a1db4d".to_owned()
 }
 
 pub fn default_storage() -> Quantity {


### PR DESCRIPTION
Update default base slim image to version [0a1db4d](https://github.com/CoreDB-io/coredb/commit/0a1db4de26abd8a436af8043bf29c4170baed9be)