### PR TITLE
[coredb-operator] update role permissions to include cronjob

### DIFF
--- a/coredb-operator/charts/coredb-operator/templates/cluster-role.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/cluster-role.yaml
@@ -22,3 +22,6 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]


### PR DESCRIPTION
Add Kubernetes Role permissions for the operator to control CronJob objects in the cluster