### PR TITLE
add correct role needed for cronjobs

### DIFF
--- a/coredb-operator/yaml/install.yaml
+++ b/coredb-operator/yaml/install.yaml
@@ -40,6 +40,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 # Binding the role to the account in coredb-operator ns
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adding correct permissions needed for `CronJob` to the `install.yaml`

This will fix a build issue with conductor https://github.com/CoreDB-io/data-plane/pull/86