### PR TITLE
revert crate update

### DIFF
--- a/coredb-operator/Cargo.lock
+++ b/coredb-operator/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.19",
  "thiserror",
  "tokio",
  "tonic 0.9.2",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.0.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
 dependencies = [
  "serde",
  "serde_json",
@@ -1201,11 +1201,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
+checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.20.0",
  "bytes",
  "chrono",
  "schemars",
@@ -1216,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.82.2"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7d3d52dd5c871991679102e80dfb192faaaa09fecdbccdd8c55af264ce7a8f"
+checksum = "414d80c69906a91e8ecf4ae16d0fb504e19aa6b099135d35d85298b4e4be3ed3"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.82.2"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544339f1665488243f79080441cacb09c997746fd763342303e66eebb9d3ba13"
+checksum = "6dc5ae0b9148b4e2ebb0dabda06a0cd65b1eed2f41d792d49787841a68050283"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -1254,7 +1254,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.82.2"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25983d07f414dfffba08c5951fe110f649113416b1d8e22f7c89c750eb2555a7"
+checksum = "98331c6f1354893f7c50da069e43a3fd1c84e55bbedc7765d9db22ec3291d07d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.82.2"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af652b642aca19ef5194de3506aa39f89d788d5326a570da68b13a02d6c5ba2"
+checksum = "e4be6ff26b9a34ce831d341e8b33bc78986a33c1be88f5bf9ca84e92e98b1dfb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1297,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.82.2"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125331201e3073707ac79c294c89021faa76c84da3a566a3749a2a93d295c98a"
+checksum = "b698eb8998b46683b0dc3c2ce72c80bc308fc8159f25afa719668c290a037a57"
 dependencies = [
  "ahash 0.8.2",
  "async-trait",
@@ -2126,6 +2126,18 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
 version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
@@ -2528,11 +2540,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2540,7 +2552,6 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -3045,6 +3056,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/coredb-operator/Cargo.toml
+++ b/coredb-operator/Cargo.toml
@@ -28,7 +28,7 @@ telemetry = ["tonic", "opentelemetry-otlp"]
 actix-web = "4.3.1"
 futures = "0.3.27"
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false }
+k8s-openapi = { version = "0.17.0", features = ["v1_24", "schemars"], default-features = false }
 schemars = { version = "0.8.12", features = ["chrono"] }
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"
@@ -55,4 +55,4 @@ tower-test = "0.4.0"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive", "ws"]
-version = "0.82.2"
+version = "0.80.0"

--- a/coredb-operator/Cargo.toml
+++ b/coredb-operator/Cargo.toml
@@ -28,7 +28,7 @@ telemetry = ["tonic", "opentelemetry-otlp"]
 actix-web = "4.3.1"
 futures = "0.3.27"
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = { version = "0.17.0", features = ["v1_24", "schemars"], default-features = false }
+k8s-openapi = { version = "0.17.0", features = ["v1_25", "schemars"], default-features = false }
 schemars = { version = "0.8.12", features = ["chrono"] }
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"

--- a/coredb-operator/src/controller.rs
+++ b/coredb-operator/src/controller.rs
@@ -21,7 +21,6 @@ use kube::{
         controller::{Action, Controller},
         events::{Event, EventType, Recorder, Reporter},
         finalizer::{finalizer, Event as Finalizer},
-        watcher,
     },
     Resource,
 };
@@ -424,7 +423,7 @@ pub async fn init(client: Client) -> (BoxFuture<'static, ()>, State) {
         info!("Installation: cargo run --bin crdgen | kubectl apply -f -");
         std::process::exit(1);
     }
-    let controller = Controller::new(cdb, watcher::Config::default())
+    let controller = Controller::new(cdb, ListParams::default())
         .shutdown_on_signal()
         .run(reconcile, error_policy, state.create_context(client))
         .filter_map(|x| async move { Result::ok(x) })


### PR DESCRIPTION
Looks like the crate update to `k8s-openapi` and `kube` cause some weird issues around being able to monitor status in the operator.  Reverting for now.

fixes: [COR-814](https://linear.app/coredb/issue/COR-814/fix-conductoroperator-status)