### PR TITLE
[postgres-image] Ensure that the latest postgresql.conf file is copied

### DIFF
--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.9"
+version = "15.2.0-coredb-pg-slim.10"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && apt-get install -y \
         && rm -rf /var/lib/apt/lists/*
 
 COPY ./postgresql.conf /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample
+COPY ./postgresql.conf /postgresql.conf.replace
 
 WORKDIR /git
 RUN git clone --branch "v${PG_VECTOR_VER}" https://github.com/pgvector/pgvector.git

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/coredb/ubuntu:22.04 as builder
 
 ARG WALG_VER=2.0.1
-ARG TRUNK_VER=0.4.6
+ARG TRUNK_VER=0.4.8
 
 RUN apt-get update && apt-get install -y curl pkg-config libssl-dev build-essential libclang-dev clang software-properties-common
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -9,7 +9,7 @@ RUN /root/.cargo/bin/cargo install --version $TRUNK_VER pg-trunk
 
 # Grab wal-g binary
 RUN curl -L -o /tmp/wal-g "https://github.com/wal-g/wal-g/releases/download/v$WALG_VER/wal-g-pg-ubuntu-20.04-amd64" \
-    && chmod +x /tmp/wal-g
+        && chmod +x /tmp/wal-g
 
 FROM quay.io/coredb/ubuntu:22.04
 
@@ -25,16 +25,14 @@ ENV TZ=Etc/UTC
 
 # Set the postgres user's permissions
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
-	mkdir -p /var/lib/postgresql; \
-	chown -R postgres:postgres /var/lib/postgresql
+    groupadd -r postgres --gid=999; \
+    useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+    mkdir -p /var/lib/postgresql; \
+    chown -R postgres:postgres /var/lib/postgresql
 
 # Installs the postgres APT repository
 # https://wiki.postgresql.org/wiki/Apt
-RUN apt-get update && apt-get install -y \
-        curl ca-certificates gnupg lsb-release \
-        && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl ca-certificates gnupg lsb-release && rm -rf /var/lib/apt/lists/*
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg > /dev/null
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
@@ -45,8 +43,8 @@ ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
 RUN set -eux; \
-	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+    apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 RUN mkdir /docker-entrypoint-initdb.d
@@ -74,12 +72,12 @@ WORKDIR /git
 RUN git clone --branch "v${PG_VECTOR_VER}" https://github.com/pgvector/pgvector.git
 WORKDIR /git/pgvector
 RUN set -xe; \
-      make; \
-      make install;
+        make; \
+        make install;
 
 WORKDIR / 
 RUN rm -rf /git
-  
+
 RUN trunk install --version ${PG_PARTMAN_VER} pg_partman
 
 # cache extensions and shared libraries

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -249,10 +249,10 @@ pg_setup_hba_conf() {
 # Make sure we always copy the correct postgresql.conf, even if it already exists
 # If postgresql.conf.sample is newer, we copy that to $PGDATA/postgresql.conf
 pg_conf_copy() {
-	local srcConf="/usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample"
+	local srcConf="/postgresql.conf.replace"
 	local dstConf="${PGDATA}/postgresql.conf"
 	if [ ! -s "$dstConf" ] || [ "$srcConf" -nt "$dstConf" ]; then
-		cp "$srcConf" "$dstConf"
+		mv "$srcConf" "$dstConf"
 	fi
 }
 
@@ -297,6 +297,9 @@ _pg_want_help() {
 }
 
 _main() {
+	# Copy postgresql.conf if PGDATA is a new volume or postgresql.conf.sample is updated
+	pg_conf_copy
+
 	# if first arg looks like a flag, assume we want to run postgres server
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
@@ -341,9 +344,6 @@ _main() {
 			EOM
 		fi
 	fi
-
-	# Copy postgresql.conf if PGDATA is a new volume or postgresql.conf.sample is updated
-	pg_conf_copy
 
 	exec "$@"
 }

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -247,12 +247,12 @@ pg_setup_hba_conf() {
 }
 
 # Make sure we always copy the correct postgresql.conf, even if it already exists
-# If postgresql.conf.sample is newer, we copy that to $PGDATA/postgresql.conf
+# If postgresql.conf.replace is newer, we copy that to $PGDATA/postgresql.conf
 pg_conf_copy() {
 	local srcConf="/postgresql.conf.replace"
-	local dstConf="${PGDATA}/postgresql.conf"
+	local dstConf="$PGDATA/postgresql.conf"
 	if [ ! -s "$dstConf" ] || [ "$srcConf" -nt "$dstConf" ]; then
-		mv "$srcConf" "$dstConf"
+	  cp "$srcConf" "$dstConf"
 	fi
 }
 
@@ -297,7 +297,7 @@ _pg_want_help() {
 }
 
 _main() {
-	# Copy postgresql.conf if PGDATA is a new volume or postgresql.conf.sample is updated
+	# Copy postgresql.conf if PGDATA is a new volume or postgresql.conf.replace is updated
 	pg_conf_copy
 
 	# if first arg looks like a flag, assume we want to run postgres server

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -246,6 +246,16 @@ pg_setup_hba_conf() {
 	} >> "$PGDATA/pg_hba.conf"
 }
 
+# Make sure we always copy the correct postgresql.conf, even if it already exists
+# If postgresql.conf.sample is newer, we copy that to $PGDATA/postgresql.conf
+pg_conf_copy() {
+	local srcConf="/usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample"
+	local dstConf="${PGDATA}/postgresql.conf"
+	if [ ! -s "$dstConf" ] || [ "$srcConf" -nt "$dstConf" ]; then
+		cp "$srcConf" "$dstConf"
+	fi
+}
+
 # start socket-only postgresql server for setting up or running scripts
 # all arguments will be passed along as arguments to `postgres` (via pg_ctl)
 docker_temp_server_start() {
@@ -331,6 +341,9 @@ _main() {
 			EOM
 		fi
 	fi
+
+	# Copy postgresql.conf if PGDATA is a new volume or postgresql.conf.sample is updated
+	pg_conf_copy
 
 	exec "$@"
 }

--- a/postgres/coredb-pg-slim/postgresql.conf
+++ b/postgres/coredb-pg-slim/postgresql.conf
@@ -838,3 +838,5 @@ shared_preload_libraries = 'pg_stat_statements,pg_cron,pgaudit,pg_partman_bgw'
 pg_partman_bgw.dbname = 'postgres'
 pg_partman_bgw.interval = 15
 pg_partman_bgw.role = 'postgres'
+restore_command = 'wal-g wal-fetch "%f" "%p"'
+recovery_target_timeline = 'latest'


### PR DESCRIPTION
Currently the `postgresql.conf` file isn't being updated or copied over after the initial setup.  If any new config options are applied, a newer Docker image will not copy them over.

Added a new function that will always check and copy over the `postgresql.conf.sample` into the `$PGDATA/postgresql.conf` .

Adding in wal recovery options as this will be needed if we have to manually restore for now.

fixes: [COR-815](https://linear.app/coredb/issue/COR-815)
related: [COR-566](https://linear.app/coredb/issue/COR-566)