### PR TITLE
update default images, make sure image is updated from coredb

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -68,8 +68,7 @@ jobs:
         # Go here for a list of versions:
         # https://github.com/kubernetes-sigs/kind/releases
         node_image:
-          - 'kindest/node:v1.25.3'
-          - 'kindest/node:v1.22.15'
+          - 'kindest/node:v1.25.8'
     steps:
       - uses: actions/checkout@v2
       - name: Create k8s Kind Cluster

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -82,7 +82,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/coredb/coredb-pg-slim:e7a4faa
+                default: quay.io/coredb/coredb-pg-slim:4fc97f3
                 type: string
               pkglibdirStorage:
                 default: 1Gi

--- a/coredb-operator/charts/coredb-operator/templates/crd.yaml
+++ b/coredb-operator/charts/coredb-operator/templates/crd.yaml
@@ -82,7 +82,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/coredb/coredb-pg-slim:7f0983b
+                default: quay.io/coredb/coredb-pg-slim:e7a4faa
                 type: string
               pkglibdirStorage:
                 default: 1Gi
@@ -96,7 +96,7 @@ spec:
                 default: true
                 type: boolean
               postgresExporterImage:
-                default: quay.io/prometheuscommunity/postgres-exporter:v0.11.1
+                default: quay.io/prometheuscommunity/postgres-exporter:v0.12.0
                 type: string
               replicas:
                 default: 1

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -38,7 +38,7 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/coredb/coredb-pg-slim:7f0983b".to_owned()
+    "quay.io/coredb/coredb-pg-slim:e7a4faa".to_owned()
 }
 
 pub fn default_storage() -> Quantity {
@@ -54,7 +54,7 @@ pub fn default_pkglibdir_storage() -> Quantity {
 }
 
 pub fn default_postgres_exporter_image() -> String {
-    "quay.io/prometheuscommunity/postgres-exporter:v0.11.1".to_owned()
+    "quay.io/prometheuscommunity/postgres-exporter:v0.12.0".to_owned()
 }
 
 pub fn default_extensions() -> Vec<Extension> {

--- a/coredb-operator/src/defaults.rs
+++ b/coredb-operator/src/defaults.rs
@@ -38,7 +38,7 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/coredb/coredb-pg-slim:e7a4faa".to_owned()
+    "quay.io/coredb/coredb-pg-slim:4fc97f3".to_owned()
 }
 
 pub fn default_storage() -> Quantity {

--- a/coredb-operator/src/statefulset.rs
+++ b/coredb-operator/src/statefulset.rs
@@ -42,6 +42,7 @@ pub fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
     let mut pvc_requests_pkglibdir: BTreeMap<String, Quantity> = BTreeMap::new();
     pvc_requests_pkglibdir.insert("storage".to_string(), cdb.spec.pkglibdirStorage.clone());
     let backup = &cdb.spec.backup;
+    let image = &cdb.spec.image;
 
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), "coredb".to_string());
@@ -113,7 +114,11 @@ pub fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
                 ..SecurityContext::default()
             }),
             name: "postgres".to_string(),
-            image: Some(default_image()),
+            image: if image.is_empty() {
+                Some(default_image())
+            } else {
+                Some(image.clone())
+            },
             resources: Some(cdb.spec.resources.clone()),
             ports: Some(vec![ContainerPort {
                 container_port: 5432,
@@ -193,7 +198,11 @@ pub fn stateful_set_from_cdb(cdb: &CoreDB) -> StatefulSet {
                     init_containers: Option::from(vec![Container {
                         env: postgres_env,
                         name: "pg-directory-init".to_string(),
-                        image: Some(default_image()),
+                        image: if image.is_empty() {
+                            Some(default_image())
+                        } else {
+                            Some(image.clone())
+                        },
                         volume_mounts: postgres_volume_mounts,
                         security_context: Some(SecurityContext {
                             // Run the init container as root


### PR DESCRIPTION
Currently we do not have a way of updating the postgres image we are using through the `coredb` CR.  The operator will always set the image in the `StatefulSet` to whatever the default is.

Remove unneeded CI task of testing on kind `v1.22`

fixes: [COR-821](https://linear.app/coredb/issue/COR-821)