### PR TITLE
Use correct image for new and existing instances

### DIFF
--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.13"
+version = "15.2.0-coredb-pg-slim.14"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.11"
+version = "15.2.0-coredb-pg-slim.12"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.12"
+version = "15.2.0-coredb-pg-slim.13"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.10"
+version = "15.2.0-coredb-pg-slim.11"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -338,8 +338,8 @@ _main() {
 
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
-      		# ensure we copy the latest configuration over
-      		update_postgresql_conf
+			# ensure we copy the lastes configuration over
+      update_postgresql_conf
 
 			docker_temp_server_stop
 			unset PGPASSWORD

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -338,8 +338,8 @@ _main() {
 
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
-			# ensure we copy the lastes configuration over
-                        update_postgresql_conf
+			# ensure we copy the lastest configuration over
+			update_postgresql_conf
 
 			docker_temp_server_stop
 			unset PGPASSWORD
@@ -348,6 +348,8 @@ _main() {
 				PostgreSQL init process complete; ready for start up.
 			EOM
 		else
+			# ensure we copy the lastest configuration over
+			update_postgresql_conf
 			cat <<-'EOM'
 				PostgreSQL Database directory appears to contain a database; Skipping initialization
 			EOM

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -338,8 +338,8 @@ _main() {
 
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
-      # ensure we copy the latest configuration over
-      update_postgresql_conf
+      		# ensure we copy the latest configuration over
+      		update_postgresql_conf
 
 			docker_temp_server_stop
 			unset PGPASSWORD

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -316,8 +316,6 @@ _main() {
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
-		# ensure we copy the latest configuration over
-		update_postgresql_conf
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec gosu postgres "$BASH_SOURCE" "$@"
@@ -340,6 +338,8 @@ _main() {
 
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
+      # ensure we copy the latest configuration over
+      update_postgresql_conf
 
 			docker_temp_server_stop
 			unset PGPASSWORD

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -339,7 +339,7 @@ _main() {
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
 			# ensure we copy the lastes configuration over
-      update_postgresql_conf
+                        update_postgresql_conf
 
 			docker_temp_server_stop
 			unset PGPASSWORD


### PR DESCRIPTION
Updating script to make sure we use the correct configuration for both new postgresql instances and established instances.