### PR TITLE
pgmq ci update

### DIFF
--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -114,7 +114,7 @@ jobs:
         run: trunk build
       - name: trunk publish
         env:
-          TRUNK_AUTH_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
         run: |
           pgmq_ver=$(stoml Cargo.toml package.version)
           pgmq_descr=$(stoml Cargo.toml package.description)

--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -84,7 +84,7 @@ jobs:
 
   publish:
     # only publish off main branch
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     name: trunk publish
     runs-on: ubuntu-22.04
     steps:
@@ -109,14 +109,14 @@ jobs:
          mv stoml_linux_amd64 stoml
          chmod +x stoml
          sudo mv stoml /usr/local/bin/
-         cargo install pg-trunk --version 0.4.6
-
-      - name: publish-to-trunk
+         cargo install pg-trunk --version 0.4.8
+      - name: trunk build
+        run: trunk build
+      - name: trunk publish
         env:
           TRUNK_AUTH_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
-        run: |
-          trunk build
+        run: 
           pgmq_ver=$(stoml Cargo.toml package.version)
           pgmq_descr=$(stoml Cargo.toml package.description)
           pgmq_repo=$(stoml Cargo.toml package.repository)
-          trunk publish pgmq --version 0.5.0 --file .trunk/pgmq-0.5.0.tar.gz --description "Message Queue for postgres" --homepage "https://github.com/CoreDB-io/coredb" --repository "https://github.com/CoreDB-io/coredb" --license "Apache-2.0"
+          trunk publish pgmq --version ${pgmq_ver} --file .trunk/pgmq-${pgmq_ver}.tar.gz --description "Message Queue for postgres" --homepage "https://github.com/CoreDB-io/coredb/pgmq" --repository "https://github.com/CoreDB-io/coredb/pgmq" --license "Apache-2.0"

--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -115,7 +115,7 @@ jobs:
       - name: trunk publish
         env:
           TRUNK_AUTH_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
-        run: 
+        run: |
           pgmq_ver=$(stoml Cargo.toml package.version)
           pgmq_descr=$(stoml Cargo.toml package.description)
           pgmq_repo=$(stoml Cargo.toml package.repository)

--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -22,65 +22,65 @@ on:
       - '.github/actions/pgx-init/**'
       - './pgmq/extension/**'
 jobs:
-  lint:
-    name: Run linters
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust minimal nightly with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "pgmq-extension-lint"
-          workspaces: |
-            pgmq/extension
-          # Additional directories to cache
-          cache-directories: |
-            /home/runner/.pgrx
-      - uses: ./.github/actions/pgx-init
-        with:
-          working-directory: pgmq/extension
-      - name: Cargo format
-        run: cargo +nightly fmt --all --check
-      - name: Clippy
-        run: cargo clippy
+  # lint:
+  #   name: Run linters
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Install Rust minimal nightly with clippy and rustfmt
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         components: rustfmt, clippy
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         prefix-key: "pgmq-extension-lint"
+  #         workspaces: |
+  #           pgmq/extension
+  #         # Additional directories to cache
+  #         cache-directories: |
+  #           /home/runner/.pgrx
+  #     - uses: ./.github/actions/pgx-init
+  #       with:
+  #         working-directory: pgmq/extension
+  #     - name: Cargo format
+  #       run: cargo +nightly fmt --all --check
+  #     - name: Clippy
+  #       run: cargo clippy
 
-  test:
-    name: Run tests
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "pgmq-extension-test"
-          workspaces: |
-            pgmq/extension
-          # Additional directories to cache
-          cache-directories: |
-            /home/runner/.pgrx
-      - uses: ./.github/actions/pgx-init
-        with:
-          working-directory: pgmq/extension
-      - name: test
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-          git clone https://github.com/pgpartman/pg_partman.git && \
-          cd pg_partman && \
-          sudo make install && cd ../
-          cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.3/pgrx-install/share/postgresql/extension/
-          cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.3/pgrx-install/lib/postgresql/
-          rm -rf ./target/pgrx-test-data-* || true
-          pg_version=$(stoml Cargo.toml features.default)
-          cargo pgrx run ${pg_version} --pgcli || true
-          cargo pgrx test ${pg_version}
+  # test:
+  #   name: Run tests
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         prefix-key: "pgmq-extension-test"
+  #         workspaces: |
+  #           pgmq/extension
+  #         # Additional directories to cache
+  #         cache-directories: |
+  #           /home/runner/.pgrx
+  #     - uses: ./.github/actions/pgx-init
+  #       with:
+  #         working-directory: pgmq/extension
+  #     - name: test
+  #       run: |
+  #         sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
+  #         git clone https://github.com/pgpartman/pg_partman.git && \
+  #         cd pg_partman && \
+  #         sudo make install && cd ../
+  #         cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.3/pgrx-install/share/postgresql/extension/
+  #         cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.3/pgrx-install/lib/postgresql/
+  #         rm -rf ./target/pgrx-test-data-* || true
+  #         pg_version=$(stoml Cargo.toml features.default)
+  #         cargo pgrx run ${pg_version} --pgcli || true
+  #         cargo pgrx test ${pg_version}
 
   publish:
     # only publish off main branch

--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -22,69 +22,69 @@ on:
       - '.github/actions/pgx-init/**'
       - './pgmq/extension/**'
 jobs:
-  # lint:
-  #   name: Run linters
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install Rust minimal nightly with clippy and rustfmt
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         components: rustfmt, clippy
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         prefix-key: "pgmq-extension-lint"
-  #         workspaces: |
-  #           pgmq/extension
-  #         # Additional directories to cache
-  #         cache-directories: |
-  #           /home/runner/.pgrx
-  #     - uses: ./.github/actions/pgx-init
-  #       with:
-  #         working-directory: pgmq/extension
-  #     - name: Cargo format
-  #       run: cargo +nightly fmt --all --check
-  #     - name: Clippy
-  #       run: cargo clippy
+  lint:
+    name: Run linters
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust minimal nightly with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "pgmq-extension-lint"
+          workspaces: |
+            pgmq/extension
+          # Additional directories to cache
+          cache-directories: |
+            /home/runner/.pgrx
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: pgmq/extension
+      - name: Cargo format
+        run: cargo +nightly fmt --all --check
+      - name: Clippy
+        run: cargo clippy
 
-  # test:
-  #   name: Run tests
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Rust stable toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         prefix-key: "pgmq-extension-test"
-  #         workspaces: |
-  #           pgmq/extension
-  #         # Additional directories to cache
-  #         cache-directories: |
-  #           /home/runner/.pgrx
-  #     - uses: ./.github/actions/pgx-init
-  #       with:
-  #         working-directory: pgmq/extension
-  #     - name: test
-  #       run: |
-  #         sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-  #         git clone https://github.com/pgpartman/pg_partman.git && \
-  #         cd pg_partman && \
-  #         sudo make install && cd ../
-  #         cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.3/pgrx-install/share/postgresql/extension/
-  #         cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.3/pgrx-install/lib/postgresql/
-  #         rm -rf ./target/pgrx-test-data-* || true
-  #         pg_version=$(stoml Cargo.toml features.default)
-  #         cargo pgrx run ${pg_version} --pgcli || true
-  #         cargo pgrx test ${pg_version}
+  test:
+    name: Run tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "pgmq-extension-test"
+          workspaces: |
+            pgmq/extension
+          # Additional directories to cache
+          cache-directories: |
+            /home/runner/.pgrx
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: pgmq/extension
+      - name: test
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
+          git clone https://github.com/pgpartman/pg_partman.git && \
+          cd pg_partman && \
+          sudo make install && cd ../
+          cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.3/pgrx-install/share/postgresql/extension/
+          cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.3/pgrx-install/lib/postgresql/
+          rm -rf ./target/pgrx-test-data-* || true
+          pg_version=$(stoml Cargo.toml features.default)
+          cargo pgrx run ${pg_version} --pgcli || true
+          cargo pgrx test ${pg_version}
 
   publish:
     # only publish off main branch
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     name: trunk publish
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pgmq_ext.yml
+++ b/.github/workflows/pgmq_ext.yml
@@ -109,7 +109,7 @@ jobs:
          mv stoml_linux_amd64 stoml
          chmod +x stoml
          sudo mv stoml /usr/local/bin/
-         cargo install pg-trunk --version 0.4.8
+         cargo install pg-trunk --version 0.4.9
       - name: trunk build
         run: trunk build
       - name: trunk publish


### PR DESCRIPTION
- update trunk version
- move `trunk build` into its own step to make debugging easier
- updates env var used by trunk cli
- pull the pgmq version from Cargo.toml