### PR TITLE
updating base pg image to work with cnpg

### DIFF
--- a/postgres/coredb-pg-base/Cargo.toml
+++ b/postgres/coredb-pg-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-base"
-version = "15.3.0-coredb-pg-base.2"
+version = "15.3.0-coredb-pg-base.3"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Base image for CoreDB's distribution of postgres"

--- a/postgres/coredb-pg-base/Dockerfile
+++ b/postgres/coredb-pg-base/Dockerfile
@@ -46,7 +46,6 @@ RUN set -eux; \
           libpam0g-dev \
           libreadline-dev \
           libssl-dev \
-          zstd \
           xz-utils \
           libnss-wrapper \
           llvm \

--- a/postgres/coredb-pg-base/Dockerfile
+++ b/postgres/coredb-pg-base/Dockerfile
@@ -1,71 +1,102 @@
+# vim:set ft=dockerfile:
 FROM quay.io/coredb/ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG ALTDIR=/var/lib/postgresql/data/tembo
 ENV TZ=Etc/UTC
-
-# Set the postgres user's permissions
-RUN set -eux; \
-	groupadd -r postgres --gid=999; \
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
-	mkdir -p /var/lib/postgresql; \
-	chown -R postgres:postgres /var/lib/postgresql
-
-RUN apt-get update && apt-get install -y \
-    curl \
-    ca-certificates \
-    gnupg \
-    lsb-release \
-    libreadline-dev \
-    zlib1g-dev \
-    libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-STOPSIGNAL SIGINT
-
 ENV PGDATA /var/lib/postgresql/data
 ENV PG_VERSION 15.3
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
+# Set the postgres user's permissions
 RUN set -eux; \
-	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+      groupadd -r postgres --gid=999; \
+      useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+      mkdir -p /var/lib/postgresql; \
+      chown -R postgres:postgres /var/lib/postgresql; \
+      apt-get update; apt-get install -y curl ca-certificates gnupg lsb-release lbzip2
+
+STOPSIGNAL SIGINT
+
+RUN set -eux; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends \
+      locales \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+	  localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# Install postgres and some extensions
-RUN apt-get update && apt-get install -y \
-        build-essential \
-        zlib1g-dev \
-        libreadline-dev \
-        libssl-dev \
-        && rm -rf /var/lib/apt/lists/*
-
 # Build Postgres from source
-RUN curl https://ftp.postgresql.org/pub/source/v15.3/postgresql-15.3.tar.bz2 -o postgresql-15.3.tar.bz2
+RUN curl https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2 -o postgresql-${PG_VERSION}.tar.bz2
 RUN tar xf postgresql-${PG_VERSION}.tar.bz2
+RUN set -eux; \
+      apt-get update && apt-get install -y \
+          libreadline-dev \
+          zlib1g-dev \
+          libpq-dev \
+          build-essential \
+          zlib1g-dev \
+          libreadline-dev \
+          libssl-dev \
+          zstd \
+          xz-utils \
+          libnss-wrapper \
+          llvm \
+          clang \
+          icu-devtools \
+          pkg-config \
+          libgss-dev \
+          libkrb5-dev \
+          uuid-dev \
+          gettext \
+      ; \
+      apt-get autoremove -y; \
+      apt-get clean -y; \
+      rm -rf /var/lib/apt/lists/*
 WORKDIR postgresql-${PG_VERSION}
-RUN ./configure --prefix=/usr/lib/postgresql/${PG_MAJOR} --datarootdir=/usr/share --with-openssl
-RUN make
+ENV CFLAGS "-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer"
+ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now" 
+RUN ./configure --prefix=/usr/lib/postgresql/${PG_MAJOR} \
+        --datarootdir=${ALTDIR} \
+        --libdir=${ALTDIR}/${PG_MAJOR}/lib \
+        --with-openssl \
+        --enable-nls \
+        --enable-thread-safety \
+        --enable-debug \
+        --disable-rpath \
+        --with-uuid=e2fs \
+        --with-gnu-ld \
+        --with-gssapi \
+        --with-pgport=5432 \
+        --with-system-tzdata=/usr/share/zoneinfo \
+        --with-icu \
+        --with-llvm
+
+RUN make -j$(nproc)
 RUN make install
 RUN cd .. && rm postgresql-${PG_VERSION}.tar.bz2
 
-COPY ./postgresql.conf /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample
+#COPY ./postgresql.conf /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample
 
 # Remove pre-installed pg_config
 RUN rm /usr/bin/pg_config
 
 # cache extensions and shared libraries
-RUN mkdir /tmp/pg_sharedir && \
-        mkdir /tmp/pg_pkglibdir && \
-        cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir && \
-        cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir
+RUN set -eux; \
+      mkdir /tmp/pg_sharedir; \
+      mkdir /tmp/pg_pkglibdir; \
+      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir; \
+      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir
+
 RUN mkdir -p /var/run/postgresql && chmod 775 /var/run/postgresql
 RUN mkdir -p /usr/share/postgresql/${PG_MAJOR}/extension && chmod 775 /usr/share/postgresql/${PG_MAJOR}/extension
-RUN chown -R postgres:postgres /usr/lib/postgresql/${PG_MAJOR} /usr/share/postgresql/extension
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+
+#COPY docker-entrypoint.sh /usr/local/bin/
+#ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER postgres
 CMD ["postgres"]

--- a/postgres/coredb-pg-base/Dockerfile
+++ b/postgres/coredb-pg-base/Dockerfile
@@ -39,7 +39,11 @@ RUN set -eux; \
           zlib1g-dev \
           libpq-dev \
           build-essential \
-          zlib1g-dev \
+          python3-dev \
+          tcl-dev \
+          libxslt1-dev \
+          libperl-dev \
+          libpam0g-dev \
           libreadline-dev \
           libssl-dev \
           zstd \
@@ -53,6 +57,10 @@ RUN set -eux; \
           libkrb5-dev \
           uuid-dev \
           gettext \
+          liblz4-dev \
+          libsystemd-dev \
+          libselinux1-dev \
+          libzstd-dev \
       ; \
       apt-get autoremove -y; \
       apt-get clean -y; \
@@ -63,6 +71,12 @@ ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
 RUN ./configure --prefix=/usr/lib/postgresql/${PG_MAJOR} \
         --datarootdir=${ALTDIR} \
         --libdir=${ALTDIR}/${PG_MAJOR}/lib \
+        --with-perl \
+        --with-python \
+        --with-tcl \
+        --with-pam \
+        --with-libxml \
+        --with-libxslt \
         --with-openssl \
         --enable-nls \
         --enable-thread-safety \
@@ -74,7 +88,11 @@ RUN ./configure --prefix=/usr/lib/postgresql/${PG_MAJOR} \
         --with-pgport=5432 \
         --with-system-tzdata=/usr/share/zoneinfo \
         --with-icu \
-        --with-llvm
+        --with-llvm \
+        --with-lz4 \
+        --with-zstd \
+        --with-systemd \
+        --with-selinux 
 
 RUN make -j$(nproc)
 RUN make install


### PR DESCRIPTION
Bringing Postgres feature parity in line with the community Postgres container image.

We are still lacking a few config flags though. 

* `--with-dtrace`
* `--enable-nls`

Fixes: [COR-1060](https://linear.app/coredb/issue/COR-1060/postgres-image-where-sharelib-and-pkglib-dir-are-inside-pgdata)
